### PR TITLE
use relative links in README

### DIFF
--- a/DIPs/archive/README.md
+++ b/DIPs/archive/README.md
@@ -1,10 +1,10 @@
-|                                                                    ID|                                                                             Title|     Status|
-|----------------------------------------------------------------------|----------------------------------------------------------------------------------|-----------|
-|[43](https://github.com/dlang/DIPs/tree/master/DIPs/archive//DIP43.md)|                                                                     D/Objective-C|   Approved|
-|[20](https://github.com/dlang/DIPs/tree/master/DIPs/archive//DIP20.md)|                                                    Volatile read/write intrinsics|Implemented|
-|[25](https://github.com/dlang/DIPs/tree/master/DIPs/archive//DIP25.md)|                                                                 Sealed references|Implemented|
-|[37](https://github.com/dlang/DIPs/tree/master/DIPs/archive//DIP37.md)|                                        Importing Packages as if They Were Modules|Implemented|
-|[42](https://github.com/dlang/DIPs/tree/master/DIPs/archive//DIP42.md)|                            Add enum E(T) = expression; eponymous template support|Implemented|
-|[56](https://github.com/dlang/DIPs/tree/master/DIPs/archive//DIP56.md)|                                       Provide pragma to control function inlining|Implemented|
-|[60](https://github.com/dlang/DIPs/tree/master/DIPs/archive//DIP60.md)|                                                      Add @nogc Function Attribute|Implemented|
-|[61](https://github.com/dlang/DIPs/tree/master/DIPs/archive//DIP61.md)|Add namespace scopes to support referencing external C++ symbols in C++ namespaces|Implemented|
+|              ID|                                                                             Title|     Status|
+|----------------|----------------------------------------------------------------------------------|-----------|
+|[43](./DIP43.md)|                                                                     D/Objective-C|   Approved|
+|[20](./DIP20.md)|                                                    Volatile read/write intrinsics|Implemented|
+|[25](./DIP25.md)|                                                                 Sealed references|Implemented|
+|[37](./DIP37.md)|                                        Importing Packages as if They Were Modules|Implemented|
+|[42](./DIP42.md)|                            Add enum E(T) = expression; eponymous template support|Implemented|
+|[56](./DIP56.md)|                                       Provide pragma to control function inlining|Implemented|
+|[60](./DIP60.md)|                                                      Add @nogc Function Attribute|Implemented|
+|[61](./DIP61.md)|Add namespace scopes to support referencing external C++ symbols in C++ namespaces|Implemented|

--- a/tools/genoverview/source/app.d
+++ b/tools/genoverview/source/app.d
@@ -14,8 +14,6 @@ void main ( string[] args )
 
     import std.format;
 
-    string urlBase = format("https://github.com/dlang/DIPs/tree/master/%s", dipFolder);
-
     import std.path, std.file, std.utf;
 
     DIPMetadata[] DIPs;
@@ -24,7 +22,7 @@ void main ( string[] args )
     {
         auto contents = cast(string) read(entry.name);
         validate(contents);
-        DIPs ~= DIPMetadata.fromAA(parseFirstMdTable(contents), urlBase);
+        DIPs ~= DIPMetadata.fromAA(parseFirstMdTable(contents));
     }
 
     import std.algorithm : sort;
@@ -115,7 +113,7 @@ void writeSummary ( DIPMetadata[] DIPs, string fileName )
 
     foreach (dip; DIPs)
     {
-        updateMax(widths.id, format("[%s](%s)", dip.id, dip.url));
+        updateMax(widths.id, format("[%s](./DIP%1$s.md)", dip.id));
         updateMax(widths.title, dip.title);
         updateMax(widths.status, to!string(dip.status));
     }
@@ -137,6 +135,6 @@ void writeSummary ( DIPMetadata[] DIPs, string fileName )
     );
 
     foreach (dip; DIPs)
-        output.writefln(lineFormat, format("[%s](%s)", dip.id, dip.url),
+        output.writefln(lineFormat, format("[%1$s](./DIP%1$s.md)", dip.id),
             dip.title, dip.status);
 }

--- a/tools/genoverview/source/metadata.d
+++ b/tools/genoverview/source/metadata.d
@@ -15,18 +15,15 @@ struct DIPMetadata
     Status status;
 
     string author;
-    string url;
 
-    static DIPMetadata fromAA ( string[string] kv, string urlBase )
+    static DIPMetadata fromAA ( string[string] kv )
     {
-        import std.conv, std.format;
+        import std.conv;
 
         DIPMetadata metadata;
         metadata.id = to!size_t(kv["DIP"]);
         metadata.title = kv["Title"];
         metadata.author = kv["Author"];
-        metadata.url = format(
-            "%s/DIP%s.md", urlBase,  metadata.id);
         metadata.status = to!Status(kv["Status"]);
         return metadata;
     }


### PR DESCRIPTION
- works w/ README on non-master branch (e.g. for PRs)
- simplifies link generation and moving files around