### PR TITLE
T func(T* t) -> T* func(T* t)

### DIFF
--- a/DIPs/DIP1000.md
+++ b/DIPs/DIP1000.md
@@ -506,7 +506,7 @@ void bar(scope T* t) @safe {
 But the following idiom is far too useful to be disallowed:
 
 ``` D
-T func(T* t) {
+T* func(T* t) {
   return t; // ok
 }
 ```


### PR DESCRIPTION
I think that is a typo. func IMO should clearly return a T* not a T.

@WalterBright @andralex 