### PR TITLE
Add and explain status 'pending implementation'

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,11 @@ community.
    authors decide it needs more research, a new topic on the
    [Dlang-study](http://lists.puremagic.com/cgi-bin/mailman/listinfo/dlang-study)
    mailing list may be initiated.
+4. Distinction between `Approved` and `Pending Implementation` status is that
+   for former just the concept itself got approval while the latter means DIP
+   document can act as a final specification for implementing it upstream.
+   Usually DIP that is only `Approved` will have remarks regarding what needs
+   to be cleaned up in spec before it can be finalized.
 
 ### Collaborating on DIPs
 

--- a/tools/genoverview/source/metadata.d
+++ b/tools/genoverview/source/metadata.d
@@ -1,11 +1,38 @@
 module metadata;
 
-enum Status
+struct Status
 {
-    Rejected,
-    Draft,
-    Approved,
-    Implemented
+    enum StatusEnum
+    {
+        Rejected,
+        Draft,
+        Approved,
+        PendingImplementation,
+        Implemented
+    }
+
+    StatusEnum value;
+    alias value this;
+
+    string toString ( )
+    {
+        static import std.conv;
+
+        if (value == Status.PendingImplementation)
+            return "Pending Implementation";
+        else
+            return std.conv.to!string(value);
+    }
+
+    static auto fromString ( string status )
+    {
+        static import std.conv;
+
+        if (status == "Pending Implementation")
+            return Status.PendingImplementation;
+        else
+            return std.conv.to!StatusEnum(status);
+    }
 }
 
 struct DIPMetadata
@@ -24,7 +51,7 @@ struct DIPMetadata
         metadata.id = to!size_t(kv["DIP"]);
         metadata.title = kv["Title"];
         metadata.author = kv["Author"];
-        metadata.status = to!Status(kv["Status"]);
+        metadata.status = Status.fromString(kv["Status"]);
         return metadata;
     }
 }


### PR DESCRIPTION
Intended to distinguish conceptually approved ideas from those
featuring ready to be implemented finalized specification.

Ping @andralex - we briefly talked about it live.