### PR TITLE
replace the term visibility with reachability

### DIFF
--- a/DIPs/DIP1000.md
+++ b/DIPs/DIP1000.md
@@ -14,7 +14,7 @@
 * [Description](#description)
   * [Benefits](#benefits)
   * [Definitions](#definitions)
-        * [Visibility vs. lifetime](#visibility-vs-lifetime)
+        * [Reachability vs. lifetime](#reachability-vs-lifetime)
         * [Algebra of Lifetimes](#algebra-of-lifetimes)
   * [Aggregates](#aggregates)
   * [Fundamentals of scope](#fundamentals-of-scope)
@@ -85,60 +85,60 @@ the function.
 
 ### Definitions
 
-#### Visibility vs. lifetime
+#### Reachability vs. lifetime
 
-For each value `v` within a program we define the notion of <i>lexical
-visibility</i> denoted as `visibility(v)`, akin to the lexical extent through
-which the value can be accessed.
+For each value `v` within a program we define the notion of <i>reachability</i>
+denoted as `reachability(v)`, akin to the lexical extent through which the value
+can be accessed.
 
-- For an rvalue, the visibility is the expression within which it is used.
-- For a named variable in a scope, the visibility is the lexical scope of the variable per the language rules.
-- For a module-level variable, visibility is considered infinite. Notation: `visibility(v)` `=` `∞`.
+- For an rvalue, the reachability is the expression within which it is used.
+- For a named variable in a scope, the reachability is the lexical scope of the variable per the language rules.
+- For a module-level variable, reachability is considered infinite. Notation: `reachability(v)` `=` `∞`.
 
-Due to language scoping rules, visibilities cannot partially intersect or
-"cross": for any two values, either they are not simultaneously visible at all,
-or one's visibility is included within the other's. We define a partial order
-among visibilities: `visibility(v1)` `<=` `visibility(v2)` if `v2` is visible
-through all portions of program when `v1` is visible (including the case where
-both values have infinite visibilities). If two variables have disjoint
-visibilities, they are unordered.
+Due to language scoping rules, reachabilities cannot partially intersect or
+"cross": for any two values, either they are not simultaneously reachable at all,
+or one's reachability is included within the other's. We define a partial order
+among reachabilities: `reachability(v1)` `<=` `reachability(v2)` if `v2` is reachable
+through all portions of program when `v1` is reachable (including the case where
+both values have infinite reachabilities). If two variables have disjoint
+reachabilities, they are unordered.
 
 We also define <i>lifetime</i> for each value, which is the extent during which
 a value can be safely used.
 
-- For types without indirections such as `int`, visibility and lifetime are equal for rvalues and lvalues.
+- For types without indirections such as `int`, reachability and lifetime are equal for rvalues and lvalues.
 - For all global and `static` variables, lifetime is infinite.
-- For values allocated on the garbage collected heap, lifetime is infinite whilst visibility is dependent on the references in the program bound to those values.
-- For an unrestricted pointer, visibility is dictated by the usual lexical scope rules. Lifetime, however is dictated by the lifetime of the data to which the pointer points to.
+- For values allocated on the garbage collected heap, lifetime is infinite whilst reachability is dependent on the references in the program bound to those values.
+- For an unrestricted pointer, reachability is dictated by the usual lexical scope rules. Lifetime, however is dictated by the lifetime of the data to which the pointer points to.
 
 Examples:
 
 ``` D
 void fun1() {
-    int x; // starting here, x becomes visible and also starts "living"
-    int y = x + 42; // lifetime(42) and visibility(42) last through the initialization expression
+    int x; // starting here, x becomes reachable and also starts "living"
+    int y = x + 42; // lifetime(42) and reachability(42) last through the initialization expression
     ...
-   // lifetime(y) and visibility(y) end here, just before those of x
-   // lifetime(x) and visibility(x) end here
+   // lifetime(y) and reachability(y) end here, just before those of x
+   // lifetime(x) and reachability(x) end here
 }
 
 void fun2() {
-    int * p; // visibility(p) occurs from here through the end of the function
+    int * p; // reachability(p) occurs from here through the end of the function
     // at this point lifetime(p) is infinite because it is null and lifetime(null) is infinite
     if (...) {
         int x;
         p = &x; // lifetime(p) is now equal to lifetime(x)
     }
-    // here lifetime(p) may have ended but p is still visible
+    // here lifetime(p) may have ended but p is still reachable
 }
 ```
 
-If a value is visible but its lifetime has ended, the program is in a
+If a value is reachable but its lifetime has ended, the program is in a
 dangerous, albeit not necessarily incorrect state. The program becomes
 undefined if the value of which lifetime has ended is actually used.
 
 This proposal ensures statically that variables in `@safe` code with the
-`scope` storage class have a lifetime that includes their visibility, so they
+`scope` storage class have a lifetime that includes their reachability, so they
 are safe to use at all times.
 
 By consequence of the above, inside a function:


### PR DESCRIPTION
- since we just switched our access protection scheme to visibility
  we should avoid using the same terminology for a different concept
- reachability is a well established term for that concept, e.g.
  https://en.wikipedia.org/wiki/Tracing_garbage_collection#Reachability_of_an_object
- I also want to implement a partial order for visiblites (protection)
  to simplify our current visiblity implementation, so here things start
  to get confusing or at least harder to search for