### PR TITLE
DIP1000: `RefCountedSlice.opAssign` should be `@system`

### DIFF
--- a/DIPs/DIP1000.md
+++ b/DIPs/DIP1000.md
@@ -670,7 +670,9 @@ basic outline of a reference counted slice is shown below:
 		if (count) ++*count;
 	}
 
-	void opAssign(RefCountedSlice rhs) {
+	// Note: Reassigning an instance passed by ref in a function with
+	// a reference to `instance[n]` can be unsafe, hence opAssign is @system
+	@system opAssign(RefCountedSlice rhs) {
 		this.__dtor();
 		payload = rhs.payload;
 		count = rhs.count;
@@ -678,7 +680,7 @@ basic outline of a reference counted slice is shown below:
 	}
 
     // Interesting fact #1: destructor can be @trusted
-	@trusted ~this()  {
+	@trusted ~this() {
 		if (count && !--*count) {
 			delete payload;
 			delete refs;
@@ -698,6 +700,9 @@ basic outline of a reference counted slice is shown below:
 that the payload is deallocated automatically when it is no longer used. It is
 usable in `@safe` code because the compiler ensures statically a `ref` to an
 element may never outlive the slice.
+
+Note: This DIP does not attempt to solve the `@system opAssign` issue. That
+case will be covered by a separate Reference Counting DIP.
 
 ### Breaking changes / deprecation process
 

--- a/DIPs/DIP1000.md
+++ b/DIPs/DIP1000.md
@@ -670,8 +670,7 @@ basic outline of a reference counted slice is shown below:
 		if (count) ++*count;
 	}
 
-	// Note: Reassigning an instance passed by ref in a function with
-	// a reference to `instance[n]` can be unsafe, hence opAssign is @system
+	// Prevent reassignment as references to payload may still exist
 	@system opAssign(RefCountedSlice rhs) {
 		this.__dtor();
 		payload = rhs.payload;
@@ -683,7 +682,7 @@ basic outline of a reference counted slice is shown below:
 	@trusted ~this() {
 		if (count && !--*count) {
 			delete payload;
-			delete refs;
+			delete count;
 		}
 	}
 
@@ -694,6 +693,10 @@ basic outline of a reference counted slice is shown below:
 
 	// ...
 }
+
+// Prevent premature destruction as references to payload may still exist
+// (defined in object.d)
+@system void destroy(T)(ref RefCountedSlice!T rcs);
 ```
 
 `RefCountedSlice` mimics the semantics of `T[]` with the notable difference
@@ -701,8 +704,26 @@ that the payload is deallocated automatically when it is no longer used. It is
 usable in `@safe` code because the compiler ensures statically a `ref` to an
 element may never outlive the slice.
 
-Note: This DIP does not attempt to solve the `@system opAssign` issue. That
-case will be covered by a separate Reference Counting DIP.
+Note: This DIP does not attempt to allow `opAssign` and `destroy` to be @safe.
+Those cases will be covered by a separate Reference Counting DIP.
+The following test demonstrates why those cases are disallowed in
+@safe code:
+
+```
+@safe unittest
+{
+    alias RCS = RefCountedSlice!int;
+    static fun(ref RCS rc, ref int ri)
+    {
+        rc = rc.init; // Error: can't call opAssign in @safe code
+        rc.destroy;   // Error: can't call destroy(RCS) in @safe code
+        ri++;         // would have been unsafe
+    }
+    auto rc = RCS(1);
+    fun(rc, rc[0]);
+    assert(rc[0] == 1);
+}
+```
 
 ### Breaking changes / deprecation process
 


### PR DESCRIPTION
`RefCountedSlice` can have a `@trusted` destructor so long as the struct instance can't be reassigned.

Ping @WalterBright @Dicebot 