### PR TITLE
Additions and edits to DIP1002 in response to criticisms

### DIFF
--- a/DIPs/DIP1002.md
+++ b/DIPs/DIP1002.md
@@ -9,9 +9,8 @@
 
 ## Abstract
 
-In Python, the try/catch/finally syntax is augmented with an additional clause,
-termed else. It is a fantastically useful addition to the conventional syntax.
-It works like this:
+In Python and Ruby, the try/catch/finally syntax is augmented with an additional clause,
+termed else. In Python, it works like this:
 
 ``` python
     try:
@@ -26,18 +25,62 @@ It works like this:
 
 ### Links
 
-* [Exception handling in Python](https://docs.python.org/3/tutorial/errors.html#handling-exceptions)
+* [Documentation regarding Python's exception handling](https://docs.python.org/3/tutorial/errors.html#handling-exceptions)
+* [Wikipedia example of error handling in Python](https://en.wikipedia.org/wiki/Exception_handling_syntax#Python)
+* [Wikipedia example of error handling in Ruby](https://en.wikipedia.org/wiki/Exception_handling_syntax#Ruby)
+* ["The Possibly Forgotten Optional `else` in Python’s `try` Statement"](https://shahriar.svbtle.com/the-possibly-forgotten-optional-else-in-python-try-statement)
 * [NG discussion thread #1](http://forum.dlang.org/thread/gruemzcqaupwptfcbefs@forum.dlang.org)
 
 ## Description
 
-The _TryStatement_ would gain an additional piece, _TryElseStatement_, which
-should be present after all _Catches_ and before a _FinallyStatement_, if any.
+The new grammar for exception handling would look like this:
 
-The code in a _TryElseStatement_ would occur after the try's _ScopeStatement_,
-would occur only if no exception was thrown, and would occur before the
-_FinallyStatement_, if any is present. If any error occurs inside a
-_TryElseStatement_, its corresponding _FinallyStatement_ is still evaluated.
+``` text
+TryStatement:
+    try ScopeStatement Catches
+    try ScopeStatement Catches FinallyStatement
+    try ScopeStatement TryElseStatement
+    try ScopeStatement Catches TryElseStatement
+    try ScopeStatement Catches TryElseStatement FinallyStatement
+    try ScopeStatement FinallyStatement
+
+Catches:
+    LastCatch
+    Catch
+    Catch Catches
+
+LastCatch:
+    catch NoScopeNonEmptyStatement
+
+Catch:
+    catch ( CatchParameter ) NoScopeNonEmptyStatement
+
+CatchParameter:
+    BasicType Identifier
+
+TryElseStatement:
+    else NoScopeNonEmptyStatement
+
+FinallyStatement:
+    finally NoScopeNonEmptyStatement
+```
+
+The _TryElseStatement_ is evaluated only when try _ScopeStatement_ does not
+result in any exceptions or errors thrown. The _TryElseStatement_ is not
+evaluated if the try _ScopeStatement_ exits with a goto, break, continue,
+return, exception, or fall-through.
+
+Exceptions or errors thrown by the _TryElseStatement_ are not caught by any
+_CatchStatement_ belonging to the owning _TryStatement_. If the owning
+_TryStatement_ has a _FinallyStatement_, then that _FinallyStatement_ is
+evaluated after the _TryElseStatement_ and is evaluated regardless
+of whether the _TryElseStatement_ results in any exceptions or errors thrown.
+The _FinallyStatement_ is always evaluated, whether the try _ScopeStatement_,
+any _CatchStatement_, or the _TryElseStatement_ exits with a goto, break,
+continue, return, exception, or fall-through.
+
+A _TryElseStatement_ may itself contain its own nested _TryStatements_ for
+error handling of operations therein.
 
 ### Rationale
 
@@ -76,9 +119,33 @@ else:
 
 ### Breaking changes / deprecation process
 
-This addition should not break any existing code.
+This addition will affect constructs such as this:
+
+``` D
+try
+    if (expression)
+        try { ... }
+        catch (Exception) { ... }
+    else { ... }
+finally { ... }
+```
+
+To retain backwards-compatibility, the above case should continue to be
+evaluated in the same way - treating the `else` as a clause related to the
+_IfExpression_ and not the _TryExpression_.
+
+In cases such as this one, the compiler should emit a warning notifying the
+user that their code has produced an ambiguity, and should state what behavior
+the compiler has defaulted to.
+
+An alternative would be to use a keyword which would not cause this or any
+similar conflict. However, `else` has become established as meaningful in
+the context of exception handling, and choosing a novel keyword may confuse
+those who are coming to D from another programming language.
 
 ### Examples
+
+#### Abstract example
 
 With the additional exception handling syntax, it would become possible to
 write code like this:
@@ -131,6 +198,114 @@ finally
 }
 ```
 
+Note that a `scope(success)` placed in the `try` statement cannot be used to
+accurately reproduce this behavior because exceptions thrown by
+`depends_on_success_of_thing` would in that case be caught by `catch` statements
+intended to handle errors produced by `do_a_thing`, but not those produced by
+`depends_on_success_of_thing`.
+
+#### Code in Phobos that could be rewritten using `else`
+
+The best examples of code that can be more elegantly written using this
+`else` clause occur in application logic, such as the example described
+above where a values were read from sensors and saved to a server. However,
+there are a few places in Phobos that could be more readable and not
+require success flags if this new syntax were employed.
+
+Here is a unittest in `phobos/std/range/package.d`:
+
+``` D
+unittest
+{
+    bool ok = true;
+    try
+    {
+        auto r2 = assumeSorted([ 677, 345, 34, 7, 5 ]);
+        debug ok = false;
+    }
+    catch (Throwable)
+    {
+    }
+    assert(ok);
+}
+```
+
+With this addition to exception handling, it could be rewritten like so:
+
+``` D
+unittest
+{
+    try
+    {
+        auto r2 = assumeSorted([ 677, 345, 34, 7, 5 ]);
+    }
+    catch (Throwable)
+    {
+    }
+    else
+    {
+        debug assert(0);
+    }
+}
+```
+
+Here is a portion of a unittest in `phobos/std/variant.d`:
+
+``` D
+// try failing conversions
+bool failed = false;
+try
+{
+    auto d = c.get!(int);
+}
+catch (Exception e)
+{
+    //writeln(stderr, e.toString);
+    failed = true;
+}
+assert(failed); // :o)
+```
+
+It could be rewritten like so:
+
+``` D
+// try failing conversions
+try
+{
+    auto d = c.get!(int);
+}
+catch (Exception e)
+{   
+}
+else
+{
+    assert(0); // :o)
+}
+```
+
+Here is a utility function defined in a unittest in `phobos/std/xml.d`:
+
+``` D
+void assertNot(string s)
+{
+    bool b = false;
+    try { decode(s,DecodeMode.STRICT); }
+    catch (DecodeException e) { b = true; }
+    assert(b,s);
+}
+```
+
+It could be rewritten like so:
+
+```
+void assertNot(string s)
+{
+    try { decode(s,DecodeMode.STRICT); }
+    catch (DecodeException e) {}
+    else { assert(0, s); }
+}
+```
+
 ## Copyright & License
 
 Copyright (c) 2016 by the D Language Foundation
@@ -151,6 +326,6 @@ Some of mentioned issues:
 
 - DIP language is too informal
 - No mention of why the similar feature has not gained traction in languages other than Python
-- Missed braking change with nested `try` -> `if/else` -> `try/catch`
+- Missed breaking change with nested `try` -> `if/else` -> `try/catch`
 - Lack of references to real project code snippets that show the improvement
 - No consideration of scope guards (which are not present in Python)

--- a/DIPs/DIP1002.md
+++ b/DIPs/DIP1002.md
@@ -65,10 +65,9 @@ FinallyStatement:
     finally NoScopeNonEmptyStatement
 ```
 
-The _TryElseStatement_ is evaluated only when try _ScopeStatement_ does not
-result in any exceptions or errors thrown. The _TryElseStatement_ is not
-evaluated if the try _ScopeStatement_ exits with a goto, break, continue,
-return, exception, or fall-through.
+The _TryElseStatement_ is not evaluated if the try _ScopeStatement_ exits with
+a goto, break, continue, return, or exception. It is evaluated only if the
+_TryElseStatement_ exits normally.
 
 Exceptions or errors thrown by the _TryElseStatement_ are not caught by any
 _CatchStatement_ belonging to the owning _TryStatement_. If the owning


### PR DESCRIPTION
- Mentioned how `else` is not exclusive to Python
- Added examples where Phobos code could be rewritten with `else` clause
- More comprehensive description of new _TryExpression_ grammar
- Address ambiguous case pointed out by Andrei
- More formal language overall