### PR TITLE
DIP1003: Remove `body` as a Keyword

### DIFF
--- a/DIPs/DIP1003.md
+++ b/DIPs/DIP1003.md
@@ -31,20 +31,23 @@ relation to D.
 - [From 2016, on the usage of body in user code](http://forum.dlang.org/thread/nyrosepldsxabewksehb@forum.dlang.org)
 - [From 2016, anecdote of the word body used in an external C library ported to D](http://forum.dlang.org/post/lxdsvhygsaesjmkmavqp@forum.dlang.org)
 
+#### Walter Bright on Conditional Keywords
+- [From 2016, Walter Bright on why he opposes contextual keywords in D](http://forum.dlang.org/post/npsp8a$mv4$1@digitalmars.com)
+
 ## Description
 
 The proposed changes to D are very simple, and are as follows:
 
-1. Remove `body` as a keyword, or in the case of [Option 1](#option-1-conditional-keyword), implement `body` as a conditional keyword.
+1. Remove `body` as a keyword, or in the case of [Option 1](#option-1-contextual-keyword), implement `body` as a contextual keyword.
 2. In the case of [Option 2](#option-2-allow-function-replace-body-after-deprecation) or [Option 3](#option-3-allow-omitting-body-then-remove-body-after-deprecation),
    the regular deprecation process for language features must be followed. Using `body` as a keyword will be deprecated, then optionally
    a warning will be added. Finally, `body` will be removed as a keyword.
 3. Allow the usage of the word "body" as a symbol name.
 
 #### Option 1: Conditional Keyword
-Keep `body` as a conditional keyword and allow it as a sybol name in all other contexts. There will be no code breakage and
+Keep `body` as a contextual keyword and allow it as a sybol name in all other contexts. There will be no code breakage and
 users will not have to adjust their code.  Therefore, this option has the easiest migration path and requires the least
-amount of user effort. However, Walter Bright strongly opposes conditional keywords and is unlikely to support their addition
+amount of user effort. However, Walter Bright [strongly opposes](#walter-bright-on-contextual-keywords) contextual keywords and is unlikely to support their addition
 to DMD on the basis that they will complicate the parser.
 
 The grammar will not have to change if this option is implemented.
@@ -52,7 +55,7 @@ The grammar will not have to change if this option is implemented.
 #### Option 2: Allow `function`, replace `body` after deprecation
 Add `function` as an optional keyword in the place of `body` and schedule the `body` keyword for deprecation. After this
 period allow `body` as a symbol name. This option will require some user effort to adjust their code and does not have
-a migration path that is as easy as [Option 1](#option-1-conditional-keyword). However, it also does not require that conditional keywords be implented.
+a migration path that is as easy as [Option 1](#option-1-contextual-keyword). However, it also does not require that contextual keywords be implented.
 
 The grammar will change as follows:
 ```
@@ -69,7 +72,7 @@ BodyStatement:
 Allow the function body to optionally be annotated with `body`, but do not require it. Schedule the `body` keyword for
 deprecation. After this period, allow body as a symbol name. This option will require roughly the same amount of user
 effort to adjust their code as [Option 2](#option-2-allow-function-replace-body-after-deprecation) and the migration path is also similar. It also does not require that
-conditional keywords are implemented. Finally, as a keyword is not necessary to designate the body of a function,
+contextual keywords are implemented. Finally, as a keyword is not necessary to designate the body of a function,
 this option will make the language more consistent in that function bodies never have to be annotated, whether they
 have a contract or not. Finally, it has the advantage of reducing the cost of D's contract syntax by 1 line, assuming
 that the `body` or `function` keyword is place on its own line ([example](#shorter-contracts)).
@@ -109,8 +112,8 @@ FunctionBody:
     FunctionContracts
 ```
 
-If the implementation of conditional keywords is rejected, the recommended option is [Option 3](#option-3-allow-omitting-body-then-remove-body-after-deprecation). [Option 2](#option-2-allow-function-replace-body-after-deprecation) is to be considered only if options 1
-and 3 are rejected. This is because [Option 1](#option-1-conditional-keyword) requires no deprecation and will not break user code, and option 3 simplifies the language as
+If the implementation of contextual keywords is rejected, the recommended option is [Option 3](#option-3-allow-omitting-body-then-remove-body-after-deprecation). [Option 2](#option-2-allow-function-replace-body-after-deprecation) is to be considered only if options 1
+and 3 are rejected. This is because [Option 1](#option-1-contextual-keyword) requires no deprecation and will not break user code, and option 3 simplifies the language as
 compared to option 2.
 
 ### Rationale
@@ -178,7 +181,7 @@ also has a relatively high cost, but a much better return on investment.
 
 ### Breaking changes / deprecation process
 
-If `body` becomes a conditional keyword, there will be no code breakage and no effort
+If `body` becomes a contextual keyword, there will be no code breakage and no effort
 required on the part of the user to change their code. Otherwise, there is the possibility
 of widespread code breakage for options 1 and 2. This will be mitigated by a long deprecation
 period of at least 2 years, giving users adequate time to update their code.
@@ -209,7 +212,7 @@ void cpBodyActivateStatic(cpBody* body_, cpShape* filter)
 ```
 
 #### Examples of How Code Will Change with This Proposal
-[Option 1:](#option-1-conditional-keyword)
+[Option 1:](#option-1-contextual-keyword)
 ```D
 //There is no change from how it is currently written in D
 int div(int a, int b)

--- a/DIPs/DIP1003.md
+++ b/DIPs/DIP1003.md
@@ -134,11 +134,11 @@ name:
 - Writing compilers and parsers (functions, loops, etc. all have bodies)
 - Scripting interfaces and wrappers
 
-#### Examples of Game Physics Library Code Ported to D That Use Body as a Symbol
+Examples of game physics library code ported to D that use body as a symbol:
 
-- [Example 1](https://github.com/d-gamedev-team/dchip/blob/55f43e5f0cf67c8bc190711b69eb16230fa6188e/src/dchip/cpBody.d#L184)
-- [Example 2](https://github.com/d-gamedev-team/dbox/blob/6f81fe065abec1e7def44fc777c5d8e9da936104/examples/demo/tests/bodytypes.d#L103)
-- [Example 3](https://github.com/rcorre/chipmunkd/commit/d6bde5b649c70a53f4295f522e660fae3c1e740f)
+- [Example 1: dchip](https://github.com/d-gamedev-team/dchip/blob/55f43e5f0cf67c8bc190711b69eb16230fa6188e/src/dchip/cpBody.d#L184)
+- [Example 2: dbox](https://github.com/d-gamedev-team/dbox/blob/6f81fe065abec1e7def44fc777c5d8e9da936104/examples/demo/tests/bodytypes.d#L103)
+- [Example 3: chipmunkd](https://github.com/rcorre/chipmunkd/commit/d6bde5b649c70a53f4295f522e660fae3c1e740f)
 
 The `body` keyword is not required from a parsing perspective; an un-annotated function block could be used
 with no difficulties. Alternatively, the `function` keyword is readily available and has the same

--- a/DIPs/DIP1003.md
+++ b/DIPs/DIP1003.md
@@ -35,8 +35,11 @@ relation to D.
 
 The proposed changes to D are very simple, and are as follows:
 
-1. Remove `body` as a keyword
-2. Allow the usage of the word "body" as a symbol name.
+1. Remove `body` as a keyword, or in the case of [Option 1](#option-1-conditional-keyword), implement `body` as a conditional keyword.
+2. In the case of [Option 2](#option-2-allow-function-replace-body-after-deprecation) or [Option 3](#option-3-allow-omitting-body-then-remove-body-after-deprecation),
+   the regular deprecation process for language features must be followed. Using `body` as a keyword will be deprecated, then optionally
+   a warning will be added. Finally, `body` will be removed as a keyword.
+3. Allow the usage of the word "body" as a symbol name.
 
 #### Option 1: Conditional Keyword
 Keep `body` as a conditional keyword and allow it as a sybol name in all other contexts. There will be no code breakage and

--- a/DIPs/DIP1003.md
+++ b/DIPs/DIP1003.md
@@ -11,10 +11,10 @@
 
 The word `body` is used in many day-to-day contexts that makes working around the
 fact that it is a keyword in D tedious. Furthermore, this removal is very often
-requested by various well known and lesser known D programmers. This DIP proposes that the
-`body` keyword be removed and the word "body" be made available for use as the
-name of a symbol. Various different methods are put forward for either replacing or
-entirely removing the role `body` currently serves in D's contract programming syntax.
+requested by various well known and lesser known D programmers. This DIP proposes that
+the `body` keyword be removed and the word "body" be made available for use as the
+name of a symbol. Various methods are put forward for either replacing or entirely
+removing the role `body` currently serves in D's contract programming syntax.
 
 This proposal assumes basic knowledge of the terms "keyword" and "symbol" in
 relation to D.
@@ -38,20 +38,20 @@ The proposed changes to D are very simple, and are as follows:
 1. Remove `body` as a keyword
 2. Allow the usage of the word "body" as a symbol name.
 
-There are several ways to accomplish this, listed in the table below:
+#### Option 1: Conditional Keyword
+Keep `body` as a conditional keyword and allow it as a sybol name in all other contexts. There will be no code breakage and
+users will not have to adjust their code.  Therefore, this option has the easiest migration path and requires the least
+amount of user effort. However, Walter Bright strongly opposes conditional keywords and is unlikely to support their addition
+to DMD on the basis that they will complicate the parser.
 
-Method of Implementation                                                                                                                                                              | Breakage    | Requires Deprecation Period?  | Recommended | Ease of User Code Adjustment | Simplicity of implementation | Comments
-:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:------------|:------------------------------|:------------|:-----------------------------|:-----------------------------|:---------
-1. Do not implement the suggested changes and do not allow `body` as a symbol name                                                                                                    | No          | No                            | No          | n/a                          | n/a                          |
-2. Replace `body` with `function` in the next release of D                                                                                                                            | Yes         | No                            | No          | Difficult                    | Simple                       | Not feasible as it abruptly breaks user code with no warning
-3. Remove `body` in the next release of D and disallow its use to denote the function body. Instead, accept an un-annotated block and allow `body` as a symbol name                   | Yes         | No                            | No          | Difficult                    | Simple                       | Not feasible as it abruptly breaks user code with no warning
-4. Keep `body` as a conditional keyword and allow it as a sybol name in all other contexts                                                                                            | No          | No                            | Yes         | Easy                         | Complex                      | Conditional keywords are opposed by Walter Bright
-5. Add `function` as an optional keyword in the place of `body` and schedule the `body` keyword for deprecation. After this period allow `body` as a symbol name                      | Yes         | Yes                           | Yes         | Moderate                     | Moderate                     |
-6. Allow the function body to optionally be annotated with `body`, but do not require it. Schedule the `body` keyword for deprecation. After this period, allow body as a symbol name | Yes         | Yes                           | Yes         | Moderate                     | Moderate                     | Makes function contracts 1 line shorter
-7. Schedule `body` for deprecation and then removal. After this period, add `function` in its place and allow `body` as a symbol name                                                 | Yes         | Yes                           | No          | Difficult                    | Moderate                     |
-8. Schedule `body` for deprecation and then removal. After this period, disallow its use to denote the function body and allow `body` as a symbol name                                | Yes         | Yes                           | No          | Difficult                    | Moderate                     | Makes function contracts 1 line shorter
+The grammar will not have to change if this option is implemented.
 
-For option 2, the grammar will change as follows:
+#### Option 2: Allow `function`, replace `body` after deprecation
+Add `function` as an optional keyword in the place of `body` and schedule the `body` keyword for deprecation. After this
+period allow `body` as a symbol name. This option will require some user effort to adjust their code and does not have
+a migration path that is as easy as option 1. However, it also does not require that conditional keywords be implented.
+
+The grammar will change as follows:
 ```
 # This
 BodyStatement:
@@ -62,7 +62,15 @@ BodyStatement:
     function BlockStatement
 ```
 
-For option 3, the grammer will change as follows:
+#### Option 3: Allow omitting `body`, then remove `body` after deprecation
+Allow the function body to optionally be annotated with `body`, but do not require it. Schedule the `body` keyword for
+deprecation. After this period, allow body as a symbol name. This option will require roughly the same amount of user
+effort to adjust their code as option 2 and the migration path is also similar. It also does not require that
+conditional keywords are implemented. Finally, as a keyword is not necessary to designate the body of a function,
+this option will make the language more consistent in that function bodies never have to be annotated, whether they
+have a contract or not.
+
+There are two ways to change the grammar to accomodate this feature:
 ```
 # This
 BodyStatement:
@@ -73,31 +81,29 @@ BodyStatement:
     BlockStatement
 ```
 
-For option 5, the grammar will change as follows:
-```
-# This
-BodyStatement:
-    body BlockStatement
+Or alternatively:
 
-# Becomes this
-BodyStatement:
-    body BlockStatement
-    function BlockStatement
 ```
-
-For option 6, the grammar will change as follows:
-```
-# This
-BodyStatement:
-    body BlockStatement
-
-# Becomes this
-BodyStatement:
-    body BlockStatement
+#This
+FunctionLiteralBody:
     BlockStatement
-```
+    FunctionContractsopt BodyStatement
 
-The grammar changes for options 7 and 8 are the same as for options 2 and 3.
+FunctionBody:
+    BlockStatement
+    FunctionContractsopt BodyStatement
+    FunctionContracts
+
+# Becomes this
+FunctionLiteralBody:
+    BlockStatement
+    FunctionContractsopt BlockStatement
+
+FunctionBody:
+    BlockStatement
+    FunctionContractsopt BlockStatement
+    FunctionContracts
+```
 
 ### Rationale
 

--- a/DIPs/DIP1003.md
+++ b/DIPs/DIP1003.md
@@ -162,12 +162,14 @@ Depending on how these changes are implemented, there will be little to no break
 and any breakage that _does_ occur will be done through the established deprecation
 process for breaking changes (first a warning, then deprecation, then removal).
 
-Overall, it is the author's opinion that option 4 is the ideal path forward for implementing this proposal and minimizing breakage. However, this
+It is the author's opinion that option 4 is the ideal path forward for implementing this proposal and minimizing breakage. However, this
 may not be feasible as it requires the implementation of conditional keywords and the effort to implement them is currently unknown. Likewise,
 option 7 and option 8 are not recommended as while they minimize code breakage within user code, they do not allow users to adjust their code
-until _after_ `body` has been removed as a keyword. Therefore, the next best options are option 5 and option 6, which are "middle of the road"
-approaches. The `body` keyword will be deprecated. Users will be warned well in advance and may update their code well before the deprecation
-and removal stages take place.
+until _after_ `body` has been removed as a keyword.
+
+As it may not be feasible to implement conditional keywords for this proposal, the recommended options are option 5 and option 6, which are
+"middle of the road" approaches. The `body` keyword will be deprecated. Users will be warned well in advance and may update their code well
+before the deprecation and removal stages take place.
 
 ### Examples
 

--- a/DIPs/DIP1003.md
+++ b/DIPs/DIP1003.md
@@ -21,15 +21,15 @@ relation to D.
 
 ### Links
 
+#### From the Spec
 - [List of Keywords in D](http://dlang.org/spec/lex.html#Keyword)
 - [Usage of the Body Keyword](http://dlang.org/spec/function.html#BodyStatement)
 - [Usage of the Function Keyword](https://dlang.org/spec/expression.html#FunctionLiteral)
-- [Previous Discussion from 2011](http://forum.dlang.org/thread/imdro4$286k$1@digitalmars.com)
-- [Current Forum Discussion on the usage of body in user code](http://forum.dlang.org/thread/nyrosepldsxabewksehb@forum.dlang.org)
-- [Example of the word body used in an external C library ported to D](http://forum.dlang.org/post/lxdsvhygsaesjmkmavqp@forum.dlang.org)
-- [Example 1 of the word body used in an external C++ library ported to D](https://github.com/d-gamedev-team/dchip/blob/55f43e5f0cf67c8bc190711b69eb16230fa6188e/src/dchip/cpBody.d#L184)
-- [Example 2 of the word body used in an external C++ library ported to D](https://github.com/d-gamedev-team/dbox/blob/6f81fe065abec1e7def44fc777c5d8e9da936104/examples/demo/tests/bodytypes.d#L103)
-- [Example 3 of the word body used in an external C++ library ported to D](https://github.com/rcorre/chipmunkd/commit/d6bde5b649c70a53f4295f522e660fae3c1e740f)
+
+#### Forum Discussion
+- [From 2011, on removing the body keyword](http://forum.dlang.org/thread/imdro4$286k$1@digitalmars.com)
+- [From 2016, on the usage of body in user code](http://forum.dlang.org/thread/nyrosepldsxabewksehb@forum.dlang.org)
+- [From 2016, anecdote of the word body used in an external C library ported to D](http://forum.dlang.org/post/lxdsvhygsaesjmkmavqp@forum.dlang.org)
 
 ## Description
 
@@ -122,6 +122,12 @@ name:
   porting these to D and creating bindings for them more difficult
 - Writing compilers and parsers (functions, loops, etc. all have bodies)
 - Scripting interfaces and wrappers
+
+#### Examples of Game Physics Library Code Ported to D That Use Body as a Symbol
+
+- [Example 1](https://github.com/d-gamedev-team/dchip/blob/55f43e5f0cf67c8bc190711b69eb16230fa6188e/src/dchip/cpBody.d#L184)
+- [Example 2](https://github.com/d-gamedev-team/dbox/blob/6f81fe065abec1e7def44fc777c5d8e9da936104/examples/demo/tests/bodytypes.d#L103)
+- [Example 3](https://github.com/rcorre/chipmunkd/commit/d6bde5b649c70a53f4295f522e660fae3c1e740f)
 
 The `body` keyword is not required from a parsing perspective; an un-annotated function block could be used
 with no difficulties. Alternatively, the `function` keyword is readily available and has the same

--- a/DIPs/DIP1003.md
+++ b/DIPs/DIP1003.md
@@ -49,7 +49,7 @@ The grammar will not have to change if this option is implemented.
 #### Option 2: Allow `function`, replace `body` after deprecation
 Add `function` as an optional keyword in the place of `body` and schedule the `body` keyword for deprecation. After this
 period allow `body` as a symbol name. This option will require some user effort to adjust their code and does not have
-a migration path that is as easy as option 1. However, it also does not require that conditional keywords be implented.
+a migration path that is as easy as [Option 1](#option-1-conditional-keyword). However, it also does not require that conditional keywords be implented.
 
 The grammar will change as follows:
 ```
@@ -65,7 +65,7 @@ BodyStatement:
 #### Option 3: Allow omitting `body`, then remove `body` after deprecation
 Allow the function body to optionally be annotated with `body`, but do not require it. Schedule the `body` keyword for
 deprecation. After this period, allow body as a symbol name. This option will require roughly the same amount of user
-effort to adjust their code as option 2 and the migration path is also similar. It also does not require that
+effort to adjust their code as [Option 2](#option-2-allow-function-replace-body-after-deprecation) and the migration path is also similar. It also does not require that
 conditional keywords are implemented. Finally, as a keyword is not necessary to designate the body of a function,
 this option will make the language more consistent in that function bodies never have to be annotated, whether they
 have a contract or not. Finally, it has the advantage of reducing the cost of D's contract syntax by 1 line, assuming
@@ -106,8 +106,8 @@ FunctionBody:
     FunctionContracts
 ```
 
-If the implementation of conditional keywords is rejected, the recommended option is option 3. Option 2 is to be considered only if options 1
-and 3 are rejected. This is because option 1 requires no deprecation and will not break user code, and option 3 simplifies the language as
+If the implementation of conditional keywords is rejected, the recommended option is option 3. [Option 2](#option-2-allow-function-replace-body-after-deprecation) is to be considered only if options 1
+and 3 are rejected. This is because [Option 1](#option-1-conditional-keyword) requires no deprecation and will not break user code, and option 3 simplifies the language as
 compared to option 2.
 
 ### Rationale
@@ -206,8 +206,9 @@ void cpBodyActivateStatic(cpBody* body_, cpShape* filter)
 ```
 
 #### Examples of How Code Will Change with This Proposal
+[Option 1:](#option-1-conditional-keyword)
 ```D
-//Current-day D, also Option 1
+//There is no change from how it is currently written in D
 int div(int a, int b)
 in { assert(b != 0); }
 body
@@ -215,7 +216,11 @@ body
     return a / b;
 }
 
-//Option 2
+auto div = function(int a, int b) in { assert(b != 0); } body { return a / b; };
+```
+
+[Option 2:](#option-2-allow-function-replace-body-after-deprecation)
+```D
 int div(int a, int b)
 in { assert(b != 0); }
 function
@@ -223,19 +228,17 @@ function
     return a / b;
 }
 
-//Option 3
+auto div = function(int a, int b) in { assert(b != 0); } function { return a / b; };
+```
+
+[Option 3:](#option-3-allow-omitting-body-then-remove-body-after-deprecation)
+```D
 int div(int a, int b)
 in { assert(b != 0); }
 {
     return a / b;
 }
 
-auto div = function(int a, int b) in { assert(b != 0); } body { return a / b; };
-
-//Option 2
-auto div = function(int a, int b) in { assert(b != 0); } function { return a / b; };
-
-//Option 3
 auto div = function(int a, int b) in { assert(b != 0); } { return a / b; };
 ```
 

--- a/DIPs/DIP1003.md
+++ b/DIPs/DIP1003.md
@@ -1,0 +1,237 @@
+# Remove `body` as a Keyword
+
+| Field           | Value                                                           |
+|-----------------|-----------------------------------------------------------------|
+| DIP:            | 1003                                                            |
+| Author:         | Jared Hanson                                                    |
+| Implementation: |                                                                 |
+| Status:         | Draft                                                           |
+
+## Abstract
+
+The word `body` is used in many day-to-day contexts that makes working around the
+fact that it is a keyword in D tedious. Furthermore, this removal is very often
+requested by various well known and lesser known D programmers. This DIP proposes that the
+`body` keyword be removed and the word "body" be made available for use as the
+name of a symbol. Various different methods are put forward for either replacing or
+entirely removing the role `body` currently serves in D's contract programming syntax.
+
+This proposal assumes basic knowledge of the terms "keyword" and "symbol" in
+relation to D.
+
+### Links
+
+- [List of Keywords in D](http://dlang.org/spec/lex.html#Keyword)
+- [Usage of the Body Keyword](http://dlang.org/spec/function.html#BodyStatement)
+- [Usage of the Function Keyword](https://dlang.org/spec/expression.html#FunctionLiteral)
+- [Previous Discussion from 2011](http://forum.dlang.org/thread/imdro4$286k$1@digitalmars.com)
+- [Current Forum Discussion on the usage of body in user code](http://forum.dlang.org/thread/nyrosepldsxabewksehb@forum.dlang.org)
+- [Example of the word body used in an external C library ported to D](http://forum.dlang.org/post/lxdsvhygsaesjmkmavqp@forum.dlang.org)
+- [Example 1 of the word body used in an external C++ library ported to D](https://github.com/d-gamedev-team/dchip/blob/55f43e5f0cf67c8bc190711b69eb16230fa6188e/src/dchip/cpBody.d#L184)
+- [Example 2 of the word body used in an external C++ library ported to D](https://github.com/d-gamedev-team/dbox/blob/6f81fe065abec1e7def44fc777c5d8e9da936104/examples/demo/tests/bodytypes.d#L103)
+- [Example 3 of the word body used in an external C++ library ported to D](https://github.com/rcorre/chipmunkd/commit/d6bde5b649c70a53f4295f522e660fae3c1e740f)
+
+## Description
+
+The proposed changes to D are very simple, and are as follows:
+
+1. Remove `body` as a keyword
+2. Allow the usage of the word "body" as a symbol name.
+
+There are several ways to accomplish this, listed in the table below:
+
+Method of Implementation                                                                                                                                                              | Breakage    | Requires Deprecation Period?  | Recommended | Ease of User Code Adjustment | Simplicity of implementation | Comments
+:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:------------|:------------------------------|:------------|:-----------------------------|:-----------------------------|:---------
+1. Do not implement the suggested changes and do not allow `body` as a symbol name                                                                                                    | No          | No                            | No          | n/a                          | n/a                          |
+2. Replace `body` with `function` in the next release of D                                                                                                                            | Yes         | No                            | No          | Difficult                    | Simple                       | Not feasible as it abruptly breaks user code with no warning
+3. Remove `body` in the next release of D and disallow its use to denote the function body. Instead, accept an un-annotated block and allow `body` as a symbol name                   | Yes         | No                            | No          | Difficult                    | Simple                       | Not feasible as it abruptly breaks user code with no warning
+4. Keep `body` as a conditional keyword and allow it as a sybol name in all other contexts                                                                                            | No          | No                            | Yes         | Easy                         | Complex                      | Conditional keywords are opposed by Walter Bright
+5. Add `function` as an optional keyword in the place of `body` and schedule the `body` keyword for deprecation. After this period allow `body` as a symbol name                      | Yes         | Yes                           | Yes         | Moderate                     | Moderate                     |
+6. Allow the function body to optionally be annotated with `body`, but do not require it. Schedule the `body` keyword for deprecation. After this period, allow body as a symbol name | Yes         | Yes                           | Yes         | Moderate                     | Moderate                     | Makes function contracts 1 line shorter
+7. Schedule `body` for deprecation and then removal. After this period, add `function` in its place and allow `body` as a symbol name                                                 | Yes         | Yes                           | No          | Difficult                    | Moderate                     |
+8. Schedule `body` for deprecation and then removal. After this period, disallow its use to denote the function body and allow `body` as a symbol name                                | Yes         | Yes                           | No          | Difficult                    | Moderate                     | Makes function contracts 1 line shorter
+
+For option 2, the grammar will change as follows:
+```
+# This
+BodyStatement:
+    body BlockStatement
+
+# Becomes this
+BodyStatement:
+    function BlockStatement
+```
+
+For option 3, the grammer will change as follows:
+```
+# This
+BodyStatement:
+    body BlockStatement
+
+# Becomes this
+BodyStatement:
+    BlockStatement
+```
+
+For option 5, the grammar will change as follows:
+```
+# This
+BodyStatement:
+    body BlockStatement
+
+# Becomes this
+BodyStatement:
+    body BlockStatement
+    function BlockStatement
+```
+
+For option 6, the grammar will change as follows:
+```
+# This
+BodyStatement:
+    body BlockStatement
+
+# Becomes this
+BodyStatement:
+    body BlockStatement
+    BlockStatement
+```
+
+The grammar changes for options 7 and 8 are the same as for options 2 and 3.
+
+### Rationale
+
+Many D programmers complain about `body` being a keyword in D (see links section for relevant discussion). It is a commonly used
+word in many different fields and as such, a programmer working in these fields will regularly come into contact with the
+fact that it is a keyword (much to their annoyance). The `body` keyword in D does not "pull its weight"; D's contract programming
+features are rarely used compared to how useful and desirable it is to be able to name a symbol "body". However, Even if D's
+contract programming features _were_ heavily used, the author believes that it would not make up for the inconvenience caused by
+`body` being a keyword. One of the reasons for this is that there is only **one** context in which body is used, compared to the
+many different contexts in user code in which the word "body" may be used as a symbol name.
+
+A partial list of the contexts in which the word `body` might be used as a symbol
+name:
+
+- In web programming where "body" is a required tag in any valid HTML document. Ex:
+- It is a name commonly used for XML tags and/or attributes
+- Physics simulations as well in astronomical contexts ("planetary bodyies", etc.)
+- Video games, such as referring to the player character's body
+- Working with HTTP requests and responses, which have a body
+- Working programmatically with emails, which have a body
+- Many external C and C++ libraries make use of "body" as a symbol name, making
+  porting these to D and creating bindings for them more difficult
+- Writing compilers and parsers (functions, loops, etc. all have bodies)
+- Scripting interfaces and wrappers
+
+The `body` keyword is not required from a parsing perspective; an un-annotated function block could be used
+with no difficulties. Alternatively, the `function` keyword is readily available and has the same
+meaning when used in the context of function contracts; it is very close in meaning to
+the `body` keyword in this context. The `body` keyword is in fact shorthand for the term
+"_function_ body", denoting the body of a function defintion that contains the actual code.
+Therefore, these changes will not be any less descriptive of what the keyword means in
+this context than the keyword `body`. It is anticipated that these changes may actually
+lead to _less_ confusion for programmers that are new to D.
+
+Also, the author believes that the `function` keyword is not as "overloaded" with different
+meanings in different contexts, like with other keywords such as `static`. Therefore, these
+proposed changes will not unduly "overload" the keyword `function`. There are currently 2
+other contexts in which the `function` keyword is already used:
+
+- Function variable type definitions
+- Function literal definitions
+
+Examples:
+```D
+int function(char c) fp; //Function variable type definition
+
+fp = function int(char c) { return 6; }; //Function literal definition
+
+int function() fp2 = function { return 0; }
+```
+
+If one considers that each keyword in a language entails a certain cost in terms of what names a
+user may use as a symbol, as well as the fact that new users must learn what each keyword means,
+then it follows that allowing `function` to be used in the context of function contracts has a much
+"cheaper" tradeoff than using `body`. Therefore, it makes sense logically to remove the `body`
+keyword, which has a high cost with a low return on investment, with the `function` keyword, which
+also has a relatively high cost, but a much better return on investment.
+
+### Breaking changes / deprecation process
+
+Depending on how these changes are implemented, there will be little to no breakage,
+and any breakage that _does_ occur will be done through the established deprecation
+process for breaking changes (first a warning, then deprecation, then removal).
+
+Overall, it is the author's opinion that option 4 is the ideal path forward for implementing this proposal and minimizing breakage. However, this
+may not be feasible as it requires the implementation of conditional keywords and the effort to implement them is currently unknown. Likewise,
+option 7 and option 8 are not recommended as while they minimize code breakage within user code, they do not allow users to adjust their code
+until _after_ `body` has been removed as a keyword. Therefore, the next best options are option 5 and option 6, which are "middle of the road"
+approaches. The `body` keyword will be deprecated. Users will be warned well in advance and may update their code well before the deprecation
+and removal stages take place.
+
+### Examples
+
+How "body" might be used as a variable name in DOM-based code:
+```D
+document.body.addEventListener("click"), (Event ev) { //Error, body is a keyword
+    ev.target.appendText("got click!");
+    ev.preventDefault();
+});
+```
+
+How "body" is currently used in physics simulation code:
+```D
+void cpBodyActivateStatic(cpBody* body_, cpShape* filter)
+{
+    cpAssertHard(cpBodyIsStatic(body_), "cpBodyActivateStatic() called on a non-static body_.");
+
+    mixin(CP_BODY_FOREACH_ARBITER!("body_", "arb", q{
+        if (!filter || filter == arb.a || filter == arb.b)
+        {
+            cpBodyActivate(arb.body_a == body_ ? arb.body_b : arb.body_a);
+        }
+    }));
+}
+```
+
+Examples of how code will change with this proposal:
+```D
+//Current-day D
+int div(int a, int b)
+in { assert(b != 0); }
+body
+{
+    return a / b;
+}
+
+//Option 5
+int div(int a, int b)
+in { assert(b != 0); }
+function
+{
+    return a / b;
+}
+
+//Option 6
+int div(int a, int b)
+in { assert(b != 0); }
+{
+    return a / b;
+}
+
+auto div = function(int a, int b) in { assert(b != 0); } body { return a / b; };
+
+//Option 5
+auto div = function(int a, int b) in { assert(b != 0); } function { return a / b; };
+
+//Option 6
+auto div = function(int a, int b) in { assert(b != 0); } { return a / b; };
+```
+
+## Copyright & License
+
+Copyright (c) 2016 by the D Language Foundation
+
+Licensed under [Creative Commons Zero 1.0](https://creativecommons.org/publicdomain/zero/1.0/legalcode.txt)
+
+### Reviews

--- a/DIPs/DIP1003.md
+++ b/DIPs/DIP1003.md
@@ -106,7 +106,7 @@ FunctionBody:
     FunctionContracts
 ```
 
-If the implementation of conditional keywords is rejected, the recommended option is option 3. [Option 2](#option-2-allow-function-replace-body-after-deprecation) is to be considered only if options 1
+If the implementation of conditional keywords is rejected, the recommended option is [Option 3](#option-3-allow-omitting-body-then-remove-body-after-deprecation). [Option 2](#option-2-allow-function-replace-body-after-deprecation) is to be considered only if options 1
 and 3 are rejected. This is because [Option 1](#option-1-conditional-keyword) requires no deprecation and will not break user code, and option 3 simplifies the language as
 compared to option 2.
 
@@ -244,7 +244,6 @@ auto div = function(int a, int b) in { assert(b != 0); } { return a / b; };
 
 #### Shorter Contracts
 ```D
-//Current-day D, also Option 1
 //This is typically how function contracts are written today
 void sqrt(int n)
 in
@@ -260,8 +259,7 @@ body
     //Implementation
 }
 
-//Option 3
-//This reduces the number of lines by 1
+//Option 3 reduces the number of lines by 1
 void sqrt(int n)
 in
 {

--- a/DIPs/DIP1003.md
+++ b/DIPs/DIP1003.md
@@ -112,7 +112,7 @@ compared to option 2.
 
 ### Rationale
 
-Many D programmers [complain](#links) about `body` being a keyword in D. It is a commonly used
+Many D programmers [complain](#forum-discussion) about `body` being a keyword in D. It is a commonly used
 word in many different fields and as such, a programmer working in these fields will regularly come into contact with the
 fact that it is a keyword (much to their annoyance). The `body` keyword in D does not "pull its weight"; D's contract programming
 features are rarely used compared to how useful and desirable it is to be able to name a symbol "body". However, Even if D's

--- a/DIPs/DIP1003.md
+++ b/DIPs/DIP1003.md
@@ -112,7 +112,7 @@ compared to option 2.
 
 ### Rationale
 
-Many D programmers [complain](#Links) about `body` being a keyword in D. It is a commonly used
+Many D programmers [complain](#links) about `body` being a keyword in D. It is a commonly used
 word in many different fields and as such, a programmer working in these fields will regularly come into contact with the
 fact that it is a keyword (much to their annoyance). The `body` keyword in D does not "pull its weight"; D's contract programming
 features are rarely used compared to how useful and desirable it is to be able to name a symbol "body". However, Even if D's

--- a/DIPs/DIP1003.md
+++ b/DIPs/DIP1003.md
@@ -178,7 +178,7 @@ also has a relatively high cost, but a much better return on investment.
 If `body` becomes a conditional keyword, there will be no code breakage and no effort
 required on the part of the user to change their code. Otherwise, there is the possibility
 of widespread code breakage for options 1 and 2. This will be mitigated by a long deprecation
-period, giving users adequate time to update their code.
+period of at least 2 years, giving users adequate time to update their code.
 
 ### Examples
 

--- a/DIPs/DIP1003.md
+++ b/DIPs/DIP1003.md
@@ -69,7 +69,7 @@ effort to adjust their code as option 2 and the migration path is also similar. 
 conditional keywords are implemented. Finally, as a keyword is not necessary to designate the body of a function,
 this option will make the language more consistent in that function bodies never have to be annotated, whether they
 have a contract or not. Finally, it has the advantage of reducing the cost of D's contract syntax by 1 line, assuming
-that the `body` or `function` keyword is place on its own line ([example](#Shorter Contracts)).
+that the `body` or `function` keyword is place on its own line ([example](#shorter-contracts)).
 
 There are two ways to change the grammar to accomodate this feature:
 ```

--- a/DIPs/DIP1003.md
+++ b/DIPs/DIP1003.md
@@ -68,7 +68,8 @@ deprecation. After this period, allow body as a symbol name. This option will re
 effort to adjust their code as option 2 and the migration path is also similar. It also does not require that
 conditional keywords are implemented. Finally, as a keyword is not necessary to designate the body of a function,
 this option will make the language more consistent in that function bodies never have to be annotated, whether they
-have a contract or not.
+have a contract or not. Finally, it has the advantage of reducing the cost of D's contract syntax by 1 line, assuming
+that the `body` or `function` keyword is place on its own line ([example](#Shorter Contracts)).
 
 There are two ways to change the grammar to accomodate this feature:
 ```
@@ -105,9 +106,13 @@ FunctionBody:
     FunctionContracts
 ```
 
+If the implementation of conditional keywords is rejected, the recommended option is option 3. Option 2 is to be considered only if options 1
+and 3 are rejected. This is because option 1 requires no deprecation and will not break user code, and option 3 simplifies the language as
+compared to option 2.
+
 ### Rationale
 
-Many D programmers complain about `body` being a keyword in D (see links section for relevant discussion). It is a commonly used
+Many D programmers [complain](#Links) about `body` being a keyword in D. It is a commonly used
 word in many different fields and as such, a programmer working in these fields will regularly come into contact with the
 fact that it is a keyword (much to their annoyance). The `body` keyword in D does not "pull its weight"; D's contract programming
 features are rarely used compared to how useful and desirable it is to be able to name a symbol "body". However, Even if D's
@@ -170,22 +175,14 @@ also has a relatively high cost, but a much better return on investment.
 
 ### Breaking changes / deprecation process
 
-Depending on how these changes are implemented, there will be little to no breakage,
-and any breakage that _does_ occur will be done through the established deprecation
-process for breaking changes (first a warning, then deprecation, then removal).
-
-It is the author's opinion that option 4 is the ideal path forward for implementing this proposal and minimizing breakage. However, this
-may not be feasible as it requires the implementation of conditional keywords and the effort to implement them is currently unknown. Likewise,
-option 7 and option 8 are not recommended as while they minimize code breakage within user code, they do not allow users to adjust their code
-until _after_ `body` has been removed as a keyword.
-
-As it may not be feasible to implement conditional keywords for this proposal, the recommended options are option 5 and option 6, which are
-"middle of the road" approaches. The `body` keyword will be deprecated. Users will be warned well in advance and may update their code well
-before the deprecation and removal stages take place.
+If `body` becomes a conditional keyword, there will be no code breakage and no effort
+required on the part of the user to change their code. Otherwise, there is the possibility
+of widespread code breakage for options 1 and 2. This will be mitigated by a long deprecation
+period, giving users adequate time to update their code.
 
 ### Examples
 
-How "body" might be used as a variable name in DOM-based code:
+#### How "body" might be used as a variable name in DOM-based code
 ```D
 document.body.addEventListener("click"), (Event ev) { //Error, body is a keyword
     ev.target.appendText("got click!");
@@ -193,7 +190,7 @@ document.body.addEventListener("click"), (Event ev) { //Error, body is a keyword
 });
 ```
 
-How "body" is currently used in physics simulation code:
+#### How "body" Is Currently Used in Physics Simulation Code
 ```D
 void cpBodyActivateStatic(cpBody* body_, cpShape* filter)
 {
@@ -208,9 +205,9 @@ void cpBodyActivateStatic(cpBody* body_, cpShape* filter)
 }
 ```
 
-Examples of how code will change with this proposal:
+#### Examples of How Code Will Change with This Proposal
 ```D
-//Current-day D
+//Current-day D, also Option 1
 int div(int a, int b)
 in { assert(b != 0); }
 body
@@ -218,7 +215,7 @@ body
     return a / b;
 }
 
-//Option 5
+//Option 2
 int div(int a, int b)
 in { assert(b != 0); }
 function
@@ -226,7 +223,7 @@ function
     return a / b;
 }
 
-//Option 6
+//Option 3
 int div(int a, int b)
 in { assert(b != 0); }
 {
@@ -235,11 +232,45 @@ in { assert(b != 0); }
 
 auto div = function(int a, int b) in { assert(b != 0); } body { return a / b; };
 
-//Option 5
+//Option 2
 auto div = function(int a, int b) in { assert(b != 0); } function { return a / b; };
 
-//Option 6
+//Option 3
 auto div = function(int a, int b) in { assert(b != 0); } { return a / b; };
+```
+
+#### Shorter Contracts
+```D
+//Current-day D, also Option 1
+//This is typically how function contracts are written today
+void sqrt(int n)
+in
+{
+    assert(n >= 0);
+}
+out (result)
+{
+    assert(result * result == n)
+}
+body
+{
+    //Implementation
+}
+
+//Option 3
+//This reduces the number of lines by 1
+void sqrt(int n)
+in
+{
+    assert(n >= 0);
+}
+out (result)
+{
+    assert(result * result == n);
+}
+{
+    //Implementation
+}
 ```
 
 ## Copyright & License

--- a/DIPs/DIP1003.md
+++ b/DIPs/DIP1003.md
@@ -55,7 +55,7 @@ The grammar will not have to change if this option is implemented.
 #### Option 2: Allow `function`, replace `body` after deprecation
 Add `function` as an optional keyword in the place of `body` and schedule the `body` keyword for deprecation. After this
 period allow `body` as a symbol name. This option will require some user effort to adjust their code and does not have
-a migration path that is as easy as [Option 1](#option-1-contextual-keyword). However, it also does not require that contextual keywords be implented.
+a migration path that is as easy as [Option 1](#option-1-contextual-keyword). However, it also does not require that contextual keywords be implemented.
 
 The grammar will change as follows:
 ```


### PR DESCRIPTION
This is the initial draft of DIP1003 for criticism and verification of acceptance criteria.
