### PR TITLE
Fix markdown spacing

### DIFF
--- a/DIPs/DIP1005.md
+++ b/DIPs/DIP1005.md
@@ -833,29 +833,29 @@ are) considered.
 * Add no syntax at all; allow top-level braces. The most Spartan of all
   syntaxes simply allows top-level scopes:
 
-```d
-{
-    import std.stdio;
-    void fun(File f) { ... }
-}
-void gun(); // no access to std.stdio here
-```
+  ```d
+  {
+      import std.stdio;
+      void fun(File f) { ... }
+  }
+  void gun(); // no access to std.stdio here
+  ```
 
-    We believe this syntax has similar advantages and disadvantages to C++
-    namespaces, which force indentation of everything within the scope. This
-    has been long considered a nuisance of C++ namespaces, worked around in
-    projects in one of two ways. One possibility is to define macros that enter
-    and leave a namespace, see e.g.
-    [1](https://www.ncbi.nlm.nih.gov/IEB/ToolBox/CPP_DOC/lxr/ident?i=BEGIN_NAMESPACE),
-    [2](http://stackoverflow.com/questions/37907516/what-is-the-macro-qt-begin-namespace-mean-in-qt-5),
-    [3](https://connect.microsoft.com/VisualStudio/feedback/details/1154097/c-intellisense-doesnt-work-correctly-with-namespace-macros),
-    [4](http://stackoverflow.com/questions/2331557/declaring-namespace-as-macro-c).
-    Another possibility is to not indent the code and have special editor
-    indentation rules, see e.g.
-    [1](http://stackoverflow.com/questions/13825188/suppress-c-namespace-indentation-in-emacs),
-    [2](http://stackoverflow.com/questions/3727862/is-there-any-way-to-make-visual-studio-stop-indenting-namespaces),
-    [3](http://stackoverflow.com/questions/2549019/how-to-avoid-namespace-content-indentation-in-vim).
-    We expect similar issues and workarounds with such a feature in D.
+  We believe this syntax has similar advantages and disadvantages to C++
+  namespaces, which force indentation of everything within the scope. This
+  has been long considered a nuisance of C++ namespaces, worked around in
+  projects in one of two ways. One possibility is to define macros that enter
+  and leave a namespace, see e.g.
+  [1](https://www.ncbi.nlm.nih.gov/IEB/ToolBox/CPP_DOC/lxr/ident?i=BEGIN_NAMESPACE),
+  [2](http://stackoverflow.com/questions/37907516/what-is-the-macro-qt-begin-namespace-mean-in-qt-5),
+  [3](https://connect.microsoft.com/VisualStudio/feedback/details/1154097/c-intellisense-doesnt-work-correctly-with-namespace-macros),
+  [4](http://stackoverflow.com/questions/2331557/declaring-namespace-as-macro-c).
+  Another possibility is to not indent the code and have special editor
+  indentation rules, see e.g.
+  [1](http://stackoverflow.com/questions/13825188/suppress-c-namespace-indentation-in-emacs),
+  [2](http://stackoverflow.com/questions/3727862/is-there-any-way-to-make-visual-studio-stop-indenting-namespaces),
+  [3](http://stackoverflow.com/questions/2549019/how-to-avoid-namespace-content-indentation-in-vim).
+  We expect similar issues and workarounds with such a feature in D.
 
 ### Breaking changes / deprecation process
 


### PR DESCRIPTION
Not sure whether you want the single-number links. They look odd. But definitely the spacing messed up the formatting of the explanatory paragraph in question.