### PR TITLE
Attributes

### DIFF
--- a/DIPs/DIPxxxx_attributes.md
+++ b/DIPs/DIPxxxx_attributes.md
@@ -35,7 +35,7 @@ overrides of individual attribute groups.
 
 ## Description
 
-Move all (DMD) compiler recongnized attributes into `core.attribute`, making them symbols in their own right, 
+Move all (DMD) compiler recognized attributes into `core.attribute`, making them symbols in their own right, 
 grouping by attribute groups into `enum`s, each with
 * a value `inferred`. The compiler shall determine the value of the attribute. It is illegal to have a function declaration `inferred`.
 * the attribute(s)

--- a/DIPs/DIPxxxx_attributes.md
+++ b/DIPs/DIPxxxx_attributes.md
@@ -35,7 +35,7 @@ e.g. `@system`,`@trusted`,`@safe` would all refer to the same enum, with inferre
 This also make attributes that do not begin with an `@` such as `nothrow` `pure` now start with an `@`, deprecate the form without the `@`.
 
 Allow tagging a module declaration with these attributes, to apply to all symbols.
-As all the attributes are now symbols we can group the in an `AliasSeq` to apply them én masse as is done in LDC for `[@fastmath](https://github.com/ldc-developers/druntime/blob/ldc/src/ldc/attributes.d#L58)`.
+As all the attributes are now symbols we can group the in an `AliasSeq` to apply them én masse as is done in LDC for [`@fastmath`](https://github.com/ldc-developers/druntime/blob/ldc/src/ldc/attributes.d#L58).
 
 Have an `AliasSeq` of the default values of the current attributes be applied when a sepcific attribute group is absent,
 taking on the current default set of attributes if none are specified.

--- a/DIPs/DIPxxxx_attributes.md
+++ b/DIPs/DIPxxxx_attributes.md
@@ -66,6 +66,7 @@ Optionally encompassed:
 Not encompassed:
 
 * @disable
+* @property
 
 ### Breaking changes / deprecation process
 

--- a/DIPs/DIPxxxx_attributes.md
+++ b/DIPs/DIPxxxx_attributes.md
@@ -125,7 +125,10 @@ if no attributes from `core.attribute` are attached.
  @core.attribute.GarbageCollectedness.inferred void baz() { someOtherFunction(); }
  
  // quux is implicily @nogc because foo is @nogc
- void quux() {} 
+ void quux();
+ 
+ // Error: declarations may not have their be be explicity inferred
+ @core.attribute.GarbageCollectedness.inferred blarg(); 
  ```
 
 ## Copyright & License

--- a/DIPs/DIPxxxx_attributes.md
+++ b/DIPs/DIPxxxx_attributes.md
@@ -23,6 +23,8 @@ propose any mechanism to remove compiler attributes directly (e.g. `@!nogc`).
 Groups of attributes that are mutually exclusive (such as `@safe`, `@system`, `@trusted`) and presence/absence attributes
 (e.g. `pure`, `nothrow`) and their (currently) non-existant logical negations are called _attribute groups_.
 
+Attributes from `core.attribute` are called core attributes.
+
 ## Rationale
 
 Many users feel that the default attributes have the wrong defaults and given that attributes are not invertable,  putting 
@@ -41,10 +43,18 @@ grouping by attribute groups into `enum`s, each with
 * the attribute(s)
 * (if applicable) the attributes' logical negation.
 
+It is suggested that 
+* `inferred` have the value 0, and the compiler shall be required to replace enum core attributes
+that have the value `inferred` to the acual value as determined by the compiler, i.e. no symbols in object files or in reflection shall
+have a core attribute with the value `inferred`. 
+* the current default have the value 1.
+* the negation of the default (`@safe` for `@safe`/`@system`/`@trusted`) the value 2.
+* any other values (e.g. `@trusted`) continue from the value 3.
+
 A module declaration may be tagged with zero or more attribute groups, to apply to all symbols (bar templates which remain inferred with explicit tagging) declared within the module acting as the default.
 If any attribute groups are absent, then the value for that attribute group default to the corresponding value in `core.attribute.defaultAttributeSet`, which will have the values of the current defauls, but may be versioned in druntime as the end user wishes, of with command line switches (e.g. `-safe` or if Type_Info / Module Info generation is added as an attribute `-betterC`).
 
-As all the attributes are now symbols we can group the in an `AliasSeq` like fashion to apply them en masse as is done in LDC for [`@fastmath`](https://github.com/ldc-developers/druntime/blob/ldc/src/ldc/attributes.d#L58).
+As all the attributes are now symbols we can group the in an `AliasSeq` like fashion to apply them en masse, as is done in LDC for [`@fastmath`](https://github.com/ldc-developers/druntime/blob/ldc/src/ldc/attributes.d#L58).
 
 It is illegal to explicitly provide more than one attribute from any given attribute group as they are mutually exclusive. 
 Attributes applied explicity to any symbol override the module default attribute set.

--- a/DIPs/DIPxxxx_attributes.md
+++ b/DIPs/DIPxxxx_attributes.md
@@ -11,7 +11,8 @@
 ## Abstract
 
 Addresses the desire for different sets of default attributes and rectifies the non-invertibilty
-of the special compiler recognised attributes.
+of the special compiler recognised attributes by having module level defaults. It does not (yet) 
+propose any mechanism to remove compiler attributes directly (e.g. `@!nogc`).
 
 ### Links
 
@@ -71,11 +72,11 @@ if no attributes from `core.attribute` are attached.
  
  `@nocg module foo;` 
  
- means that all symbols in this module are implicity `@nogc` (with `nogc` referring to `core.attribute.GarbageCollectedness.nogc`),
+ means that all symbols in this module are implicity `@nogc` (with `nogc` referring to `core.attribute.GarbageCollectedness.nogc` via an alias in `core.attribute`),
  but otherwise has all the same defaults as the default attribute set.
  
  `@nogc @core.attribute.GarbageCollectedness.gc module foo;` 
- shall be an error because there are two explicit conflicting attribute.
+ shall be an error because there are two explicit mutually exclusive attributes.
  Likewise 
  ```
  module foo;
@@ -92,6 +93,9 @@ if no attributes from `core.attribute` are attached.
  
  // baz's gc'ness is determined by someOtherFunction
  @core.attribute.GarbageCollectedness.inferred void baz() { someOtherFunction(); }
+ 
+ // quux is implicily @nogc because foo is @nogc
+ void quux() {} 
  ```
 
 ## Copyright & License

--- a/DIPs/DIPxxxx_attributes.md
+++ b/DIPs/DIPxxxx_attributes.md
@@ -35,7 +35,7 @@ overrides of individual attribute groups.
 
 ## Description
 
-Move all (DMD) compiler recongnised attributes into `core.attribute`, making them symbols in their own right, 
+Move all (DMD) compiler recongnized attributes into `core.attribute`, making them symbols in their own right, 
 grouping by attribute groups into `enum`s, each with
 * a value `inferred`. The compiler shall determine the value of the attribute. It is illegal to have a function declaration `inferred`.
 * the attribute(s)
@@ -44,9 +44,9 @@ grouping by attribute groups into `enum`s, each with
 A module declaration may be tagged with zero or more attribute groups, to apply to all symbols (bar templates which remain inferred with explicit tagging) declared within the module acting as the default.
 If any attribute groups are absent, then the value for that attribute group default to the corresponding value in `core.attribute.defaultAttributeSet`, which will have the values of the current defauls, but may be versioned in druntime as the end user wishes, of with command line switches (e.g. `-safe`).
 
-As all the attributes are now symbols we can group the in an `AliasSeq` like fashion to apply them én masse as is done in LDC for [`@fastmath`](https://github.com/ldc-developers/druntime/blob/ldc/src/ldc/attributes.d#L58).
+As all the attributes are now symbols we can group the in an `AliasSeq` like fashion to apply them en masse as is done in LDC for [`@fastmath`](https://github.com/ldc-developers/druntime/blob/ldc/src/ldc/attributes.d#L58).
 
-It is illegl to explicitly provide more than one attribute from any given attribute group as they are mutually exclusive. 
+It is illegal to explicitly provide more than one attribute from any given attribute group as they are mutually exclusive. 
 Attributes applied explicity to any symbol override the module default attribute set.
 
 ### Breaking changes / deprecation process

--- a/DIPs/DIPxxxx_attributes.md
+++ b/DIPs/DIPxxxx_attributes.md
@@ -1,0 +1,88 @@
+# Attributes
+
+| Field           | Value                                                           |
+|-----------------|-----------------------------------------------------------------|
+| DIP:            | (number/id)                                                     |
+| Review Count:   | 0
+| Author:         | Nicholas Wilson                                                 |
+| Implementation: | (links to implementation PR if any)                             |
+| Status:         | Will be set by the DIP manager (e.g. "Approved" or "Rejected")  |
+
+## Abstract
+
+Addresses the desire for different sets of default attributes.
+
+### Links
+
+[Forum discussion](https://forum.dlang.org/thread/wnddmlmfinqqfccdlhqc@forum.dlang.org)
+
+## Rationale
+
+State a short motivation about the importance and benefits of the proposed
+change.  An existing, well-known issue or a use case for an existing projects
+can greatly increase the chances of the DIP being understood and carefully
+evaluated.
+
+Many users feel that the default attributes have thr wrong defaults.
+Attributes are not invertable.
+
+## Description
+
+Move all (DMD) compiler recongnised attributes into `core.attribute`, making them symbols in their own right.
+
+Group mutually exclusive attributes together (making them different members of the same `enum`) with an additional value of infered,
+e.g. `@system`,`@trusted`,`@safe` would all refer to the same enum, with inferred being the default. This is called an _attribute group_.
+This also make attributes that do not begin with an `@` such as `nothrow` `pure` now start with an `@`, deprecate the form without the `@`.
+
+Allow tagging a module declaration with these attributes, to apply to all symbols.
+As all the attributes are now symbols we can group the in an `AliasSeq` to apply them én masse as is done in LDC for `[@fastmath](https://github.com/ldc-developers/druntime/blob/ldc/src/ldc/attributes.d#L58)`.
+
+Have an `AliasSeq` of the default values of the current attributes be applied when a sepcific attribute group is absent,
+taking on the current default set of attributes if none are specified.
+
+It is illegl to provide more than one mutually exclusive attribute from any given attribute group. 
+Attributes applied explicity override the module default attribute set.
+
+The attributes of templates shall conform to the attributes of the point of instansiation (with the defaults of being inferred shall be no change).
+
+### Breaking changes / deprecation process
+
+Use of the current attributes that are not prefiex by an `@` such as `pure` and `nothrow`,
+and optionally other modifiers that are attribute like such as `final` will be changed to refer to the `core.attribute` symbols,
+and their use without the leading `@` will be deprecated.
+
+No breaking changes are expected.
+
+### Examples
+
+`module foo;` will become synonymous with `@core.attribute.defaultAttributeSet module foo;` 
+(`core.attribute` will be implictly imported, by `object.d`)
+
+ attribute groups may be selectivly added 
+ `@nocg module foo;` - all symbols in this module are implicity `@nogc` with `nogc` reffering to `core.attribute.GarbageCollectedness.nogc`,
+ but otherwise has all the same defaults as the default attribute set.
+ 
+ `@nogc @core.attribute.GarbageCollectedness.gc module foo;` shall be an error because there are two explicit conflicting attribute.
+ likewise 
+ ```
+ module foo;
+ @nogc @core.attribute.GarbageCollectedness.gc module foo;
+ ```
+ shall be an error for the same reasons.
+ ```
+ @nogc module foo;
+ @core.attribute.GarbageCollectedness.gc void bar() {new int;} // bar overrides the default @nogc'ness of the module and is @gc
+ @core.attribute.GarbageCollectedness.inferred void baz() { someOtherFunction(); } // baz's gc'ness is determined by someOtherFunction
+ ```
+
+## Copyright & License
+
+Copyright (c) 2017 by the D Language Foundation
+
+Licensed under [Creative Commons Zero 1.0](https://creativecommons.org/publicdomain/zero/1.0/legalcode.txt)
+
+## Review
+
+Will contain comments / requests from language authors once review is complete,
+filled out by the DIP manager - can be both inline and linking to external
+document.

--- a/DIPs/DIPxxxx_attributes.md
+++ b/DIPs/DIPxxxx_attributes.md
@@ -10,7 +10,8 @@
 
 ## Abstract
 
-Addresses the desire for different sets of default attributes.
+Addresses the desire for different sets of default attributes and rectifies the non-invertibilty
+of the special compiler recognised attributes.
 
 ### Links
 
@@ -23,8 +24,7 @@ Groups of attributes that are mutually exclusive (such as `@safe`, `@system`, `@
 
 ## Rationale
 
-Many users feel that the default attributes have the wrong defaults.
-Attributes are not invertable, thus putting 
+Many users feel that the default attributes have the wrong defaults and given that attributes are not invertable,  putting 
 ```
 pure: nothrow: @nogc: @safe:
 ```
@@ -36,35 +36,41 @@ overrides of individual attribute groups.
 
 Move all (DMD) compiler recongnised attributes into `core.attribute`, making them symbols in their own right, 
 grouping by attribute groups into `enum`s, each with
-* a default value `inferred`. The compiler shall determine the value of the attribute. It is illegal to forward declare a function `inferred`.
+* a value `inferred`. The compiler shall determine the value of the attribute. It is illegal to have a function declaration `inferred`.
 * the attribute(s)
 * (if applicable) the attributes' logical negation.
 
 A module declaration may be tagged with zero or more attribute groups, to apply to all symbols (bar templates which remain inferred with explicit tagging) declared within the module acting as the default.
-If any attribute groups are absent, then the value for that attribute group default to the corresponding value in `core.attribute.defaultAttributeSet`, which will have the values of the current defauls, but may be versioned in druntime as the end user wishes.
+If any attribute groups are absent, then the value for that attribute group default to the corresponding value in `core.attribute.defaultAttributeSet`, which will have the values of the current defauls, but may be versioned in druntime as the end user wishes, of with command line switches (e.g. `-safe`).
+
 As all the attributes are now symbols we can group the in an `AliasSeq` like fashion to apply them én masse as is done in LDC for [`@fastmath`](https://github.com/ldc-developers/druntime/blob/ldc/src/ldc/attributes.d#L58).
 
-It is illegl to explicitly provide more than one (mutually exclusive) attribute from any given attribute group. 
-Attributes applied explicity override the module default attribute set.
+It is illegl to explicitly provide more than one attribute from any given attribute group as they are mutually exclusive. 
+Attributes applied explicity to any symbol override the module default attribute set.
 
 ### Breaking changes / deprecation process
 
 Use of the current attributes that are not prefiex by an `@` such as `pure` and `nothrow`,
 and optionally other modifiers that are attribute like such as `final` will be changed to refer to the `core.attribute` symbols,
-and their use without the leading `@` will be deprecated.
+and thus their use without the leading `@` will be deprecated.
 
 No breaking changes are expected.
 
 ### Examples
 
 `module foo;` 
+
 will become implicitly 
+
 `@core.attribute.defaultAttributeSet module foo;` 
+
 with respect to attributes (`core.attribute` will be implicitly imported, by `object.d`), 
 if no attributes from `core.attribute` are attached.
 
  Attribute groups may be selectivly added to the module declaration, so that:
+ 
  `@nocg module foo;` 
+ 
  means that all symbols in this module are implicity `@nogc` (with `nogc` referring to `core.attribute.GarbageCollectedness.nogc`),
  but otherwise has all the same defaults as the default attribute set.
  

--- a/DIPs/DIPxxxx_attributes.md
+++ b/DIPs/DIPxxxx_attributes.md
@@ -131,6 +131,47 @@ if no attributes from `core.attribute` are attached.
  @core.attribute.GarbageCollectedness.inferred blarg(); 
  ```
 
+As the core attributes are now also regular attributes we can manipulte them as such:
+
+```
+version(SafeD) // hypothetically set by -safe on the command line
+{
+    alias __defaultSafetyAttribute = FunctionSafety.safe;
+}
+else
+{
+    alias __defaultSafetyAttribute = FunctionSafety.system; // or inferred
+}
+// Similarly for the other core attributes
+
+alias defaultAttributeSet = AliasSeq!(__defaultSafetyAttribute, __defaultThrowAttribute, ...); // ... meaning and so on
+```
+
+A similar approach could be used to always have -betterC imply `@nothrow @nogc` (and Typeinfo emission if it were to come under the control of an attribute).
+
+It is also possible to conveniently infer multiple attributes at once:
+
+```
+template infer(Attrs...)
+{
+    static if (Attrs.length == 0) alias infer = AliasSeq!();
+    else static if (is(typeof(Attr[0] == cast(typeof(Attrs[0]))0))) // if e is a value of an enum
+    {
+        alias infer = AliasSeq!(typeof(Attr[0]).inferred,infer!(Attrs[1 .. $]));
+    }
+    else 
+        alias infer = AliasSeq!(Attr[0].inferred,infer!(Attrs[1 .. $]));
+
+}
+```
+
+and can be used like
+
+```
+@infer!(nogc,FunctionSafety) module foo;
+```
+to infer attributes by either the core attribute enum (`FunctionSafety` in the above example) or a value of that enum (`nogc` in the above example).
+
 ## Copyright & License
 
 Copyright (c) 2017 by the D Language Foundation

--- a/DIPs/DIPxxxx_attributes.md
+++ b/DIPs/DIPxxxx_attributes.md
@@ -52,7 +52,7 @@ have a core attribute with the value `inferred`.
 * any other values (e.g. `@trusted`) continue from the value 3.
 
 A module declaration may be tagged with zero or more attribute groups, to apply to all symbols (bar templates which remain inferred with explicit tagging) declared within the module acting as the default.
-If any attribute groups are absent, then the value for that attribute group default to the corresponding value in `core.attribute.defaultAttributeSet`, which will have the values of the current defauls, but may be versioned in druntime as the end user wishes, of with command line switches (e.g. `-safe` or if Type_Info / Module Info generation is added as an attribute `-betterC`).
+If any attribute groups are absent, then the value for that attribute group default to the corresponding value in `core.attribute.defaultAttributeSet`, which will have the values of the current defauls, but may be versioned in druntime as the end user wishes, or with command line switches (e.g. `-safe` or if Type_Info / Module Info generation is added as an attribute `-betterC`).
 
 As all the attributes are now symbols we can group the in an `AliasSeq` like fashion to apply them en masse, as is done in LDC for [`@fastmath`](https://github.com/ldc-developers/druntime/blob/ldc/src/ldc/attributes.d#L58).
 
@@ -127,7 +127,7 @@ if no attributes from `core.attribute` are attached.
  // quux is implicily @nogc because foo is @nogc
  void quux();
  
- // Error: declarations may not have their be be explicity inferred
+ // Error: declarations may not have their attributes be explicity inferred
  @core.attribute.GarbageCollectedness.inferred blarg(); 
  ```
 

--- a/DIPs/DIPxxxx_attributes.md
+++ b/DIPs/DIPxxxx_attributes.md
@@ -90,7 +90,7 @@ if no attributes from `core.attribute` are attached.
 
  Attribute groups may be selectivly added to the module declaration, so that:
  
- `@nocg module foo;` 
+ `@nogc module foo;` 
  
  means that all symbols in this module are implicity `@nogc` (with `nogc` referring to `core.attribute.GarbageCollectedness.nogc` via an alias in `core.attribute`),
  but otherwise has all the same defaults as the default attribute set.

--- a/DIPs/DIPxxxx_attributes.md
+++ b/DIPs/DIPxxxx_attributes.md
@@ -42,20 +42,39 @@ grouping by attribute groups into `enum`s, each with
 * (if applicable) the attributes' logical negation.
 
 A module declaration may be tagged with zero or more attribute groups, to apply to all symbols (bar templates which remain inferred with explicit tagging) declared within the module acting as the default.
-If any attribute groups are absent, then the value for that attribute group default to the corresponding value in `core.attribute.defaultAttributeSet`, which will have the values of the current defauls, but may be versioned in druntime as the end user wishes, of with command line switches (e.g. `-safe`).
+If any attribute groups are absent, then the value for that attribute group default to the corresponding value in `core.attribute.defaultAttributeSet`, which will have the values of the current defauls, but may be versioned in druntime as the end user wishes, of with command line switches (e.g. `-safe` or if Type_Info / Module Info generation is added as an attribute `-betterC`).
 
 As all the attributes are now symbols we can group the in an `AliasSeq` like fashion to apply them en masse as is done in LDC for [`@fastmath`](https://github.com/ldc-developers/druntime/blob/ldc/src/ldc/attributes.d#L58).
 
 It is illegal to explicitly provide more than one attribute from any given attribute group as they are mutually exclusive. 
 Attributes applied explicity to any symbol override the module default attribute set.
 
+### Attributes & attribute like compiler behaviour encompassed in this DIP
+
+Encompassed:
+
+* pure
+* @nothrow
+* @nogc
+* @safe/@system/@trusted
+
+Optionally encompassed:
+
+* final
+* Type_Info / Module Info generation (other components of -betterC?)
+
+Not encompassed:
+
+* @disable
+
 ### Breaking changes / deprecation process
 
 Use of the current attributes that are not prefiex by an `@` such as `pure` and `nothrow`,
 and optionally other modifiers that are attribute like such as `final` will be changed to refer to the `core.attribute` symbols,
-and thus their use without the leading `@` will be deprecated.
+and thus their use without the leading `@` will be deprecated. 
 
-No breaking changes are expected.
+No breaking changes are intended, although the introduction of the new enum symbols to be implicitly imported by `object.d`
+may break some code if the names chosen clash (unlikely).
 
 ### Examples
 

--- a/DIPs/DIPxxxx_attributes.md
+++ b/DIPs/DIPxxxx_attributes.md
@@ -56,8 +56,6 @@ As all the attributes are now symbols we can:
 * group them in an `AliasSeq` like fashion to apply them en masse, as is done in LDC for [`@fastmath`](https://github.com/ldc-developers/druntime/blob/ldc/src/ldc/attributes.d#L58)
 * mutate the `AliasSeq`s with compile time computations.
 
-A master set of atributes, `core.attribute.defaultAttributeSet`
-
 A module declaration may be tagged with zero or more attribute groups to apply to all symbols declared within the module acting as the default, with except of templates which remain inferred with explicit tagging.
 Any attribute groups not provided will be inserted into the modules' attribute list from `core.attribute.defaultAttributeSet`, the master set of atributes. 
 


### PR DESCRIPTION
Proposes that
* special compiler attributes become normal attributes in `core.attribute` grouped by mutual exclusivity.
* (special) attributes applied to a module declaration provide a default to non-template symbols in that module.
* they can be overridden explicitly.