### PR TITLE
DIP1010: Replace string mixin with mixin identifier

### DIFF
--- a/DIPs/DIP1010.md
+++ b/DIPs/DIP1010.md
@@ -394,7 +394,7 @@ Currently, the only declarations that are local to the `static foreach` body ins
 static foreach(i;0..10){
     __local import std.conv: text;
     __local enum name = text("foo",i); // note: no multiple declaration error
-    mixin(text("int ",name,"(int x){ return i+x; }"));
+    int mixin(name)(int x){ return i+x; }
     static foreach(j;-10..10)
         static assert(mixin(name)(j) == i+j);
 }


### PR DESCRIPTION
Helps readability and consistency with `mixin(name)` 2 lines below.

Ping @tgehr 