### PR TITLE
Minor editorial changes (whitespace)

### DIFF
--- a/DIPs/DIP1010.md
+++ b/DIPs/DIP1010.md
@@ -53,7 +53,7 @@ enum z=3;
 ```
 
 ```D
-foreach(v;AliasSeq!(x,y,z)) { ... }
+foreach (v; AliasSeq!(x,y,z)) { ... }
 ```
 
 This will lower to:
@@ -69,7 +69,7 @@ This is often fine behaviour, but sometimes one may want to force the loop varia
 **New**: `enum` is allowed as a storage class for a unrolled `foreach` loop variable:
 
 ```D
-foreach(enum v; AliasSeq!(x,y,z)) { ... }
+foreach (enum v; AliasSeq!(x,y,z)) { ... }
 ```
 will lower to:
 
@@ -82,7 +82,7 @@ will lower to:
 **New**: unrolled `foreach` statements can declare a loop `alias`:
 
 ```D
-foreach(alias v; AliasSeq!(x,y,z)) { }
+foreach (alias v; AliasSeq!(x,y,z)) { }
 ```
 will lower to
 
@@ -102,7 +102,7 @@ will lower to
 ```D
 mixin({
     string s="";
-    foreach (i;0..10)
+    foreach (i; 0 .. 10)
     {
         s~=generateBody(i);
     }
@@ -114,7 +114,7 @@ mixin({
 The unrolled `foreach` statement exists:
 
 ```D
-foreach(i; AliasSeq!(0,1,2,3,4,5,6,7,8,9,10)) { ... }
+foreach (i; AliasSeq!(0,1,2,3,4,5,6,7,8,9,10)) { ... }
 ```
 
 This is always a statement and it cannot generate externally visible declarations.
@@ -127,7 +127,7 @@ In more detail:
 If the aggregate `a` is a sequence or an array, the body is copied `a.length` times. Within the `i`-th copy, the name of the `static foreach` variable is bound to the `i`-th entry of the sequence or array, either as an `enum` variable declaration (for constants) or an `alias` declaration (for symbols). (In particular, `static foreach` variables are never runtime variables.)
 
 ```D
-static foreach(i; [0,1,2,3])
+static foreach (i; [0,1,2,3])
 {
     pragma(msg, i);
 }
@@ -136,7 +136,7 @@ static foreach(i; [0,1,2,3])
 Multiple `static foreach` variables are supported too.
 
 ```D
-static foreach(i, v; ['a','b','c','d'])
+static foreach (i, v; ['a','b','c','d'])
 {
     static assert(i + 'a' == v);
 }
@@ -149,7 +149,7 @@ static foreach(i, v; ['a','b','c','d'])
 A `static foreach` body does not introduce a new scope, therefore it can be used to generate declarations:
 
 ```D
-static foreach(i; iota(0,3).map!text)
+static foreach (i; iota(0,3).map!text)
 {
     mixin(`enum x`~i~`=i;`);
 }
@@ -165,7 +165,7 @@ int test(int x)
     int r = -1;
     switch(x)
     {
-        static foreach(i; 0 .. 100)
+        static foreach (i; 0 .. 100)
         {
             case i:
                 r = i;
@@ -175,7 +175,7 @@ int test(int x)
     }
     return r;
 }
-static foreach(i; 0 .. 200)
+static foreach (i; 0 .. 200)
 {
     static assert(test(i) == (i < 100 ? i : -1));
 }
@@ -269,7 +269,7 @@ alias BaseClass(T) = BaseClassesTuple!T[0];
 
 abstract class Visitor
 {
-    static foreach(T; Ts)
+    static foreach (T; Ts)
     {
         void visit(T t)
         {
@@ -345,7 +345,7 @@ T foo(T)(ref T thing)
     thing++; return thing * 2;
 }
 
-static foreach(Type; AliasSeq!(int, long, uint))
+static foreach (Type; AliasSeq!(int, long, uint))
 {
     unittest
     {
@@ -392,7 +392,7 @@ This DIP focuses on aspects of `static foreach` that are as uncontroversial as p
 One use case of `static foreach` is generating multiple declarations with different names. Currently, the only way to accomplish this is to turn the entire declaration whose name should vary into a string mixin. In this case, `static foreach` is not as much of an improvement as it could be. To mitigate this, we could allow [mixin identifiers](https://forum.dlang.org/post/ml51m4$tl9$1@digitalmars.com), as proposed by Idan Arye. (They would be useful beyond `static foreach` applications.)
 
 ```D
-static foreach(ident;["foo","bar"])
+static foreach (ident; ["foo","bar"])
 {
     auto mixin(ident)()
     {
@@ -408,12 +408,12 @@ This DIP does not propose adding mixin identifiers.
 Currently, the only declarations that are local to the `static foreach` body instead of inserted into the enclosing scope are the loop variables themselves. It could be useful to allow declarations that are local to the `static foreach` body.
 
 ```D
-static foreach(i; 0 .. 10)
+static foreach (i; 0 .. 10)
 {
     __local import std.conv: text;
     __local enum name = text("foo",i); // note: no multiple declaration error
     mixin(text("int ",name,"(int x){ return i+x; }"));
-    static foreach(j;-10..10)
+    static foreach (j; -10 .. 10)
         static assert(mixin(name)(j) == i+j);
 }
 ```
@@ -427,7 +427,7 @@ This DIP does not propose a mechanism to keep state between loop iterations. Thi
 ```D
 template staticMap(alias F, T...)
 {
-    static foreach(i; 0 .. T.length)
+    static foreach (i; 0 .. T.length)
     {
         static if (i == 0) __local alias previous = AliasSeq!();
         else __local alias previous = __previous.current;
@@ -444,7 +444,7 @@ This feature is already implemented, but would be disabled prior to merging. The
 We could provide imperative control flow constructs for controlling `static foreach` expansion, but this DIP does not propose adding them.
 
 ```D
-static foreach(i;iota(int.max))
+static foreach (i; iota(int.max))
 {
     static if (i^^3 > 123) static break;
     if (i%2 != 0) static continue;
@@ -457,13 +457,13 @@ static foreach(i;iota(int.max))
 Currently, it is an error to use `alias` or `enum` on a regular `foreach` loop:
 
 ```D
-foreach(enum i; 0 .. 3){ ... } // error
+foreach (enum i; 0 .. 3){ ... } // error
 ```
 
 It has been suggested that this should instead unroll the loop, such that it becomes equivalent to:
 
 ```D
-foreach(enum i; AliasSeq!(0,1,2)) { ... }
+foreach (enum i; AliasSeq!(0,1,2)) { ... }
 ```
 
 ## Copyright & License


### PR DESCRIPTION
The use of whitespace around ";" and ".." was inconsistent, this brings all uses to the same convention.