### PR TITLE
Can't trim whitespace, this is markdown!!

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,4 +5,3 @@ charset = utf-8
 end_of_line = lf
 indent_style = space
 indent_size = 4
-trim_trailing_whitespace = true


### PR DESCRIPTION
Double-space at the end of lines is a line-break in markdown.
The editorconfig can't go stripping all newlines in the document every time you press ctrl-S! >_<