### PR TITLE
fix issue 19062 - Accepted grammar for DIP 1009 introduces the `InExpression` which already exists

### DIFF
--- a/DIPs/accepted/DIP1009.md
+++ b/DIPs/accepted/DIP1009.md
@@ -277,7 +277,7 @@ However, in contrast to before, multiple `in` and `out` contracts are now allowe
 
 Grammar changes:
 
-```diff
+```
 AssertExpression:
 -    assert ( AssignExpression ,[opt] )
 -    assert ( AssignExpression , AssignExpression ,[opt] )

--- a/DIPs/accepted/DIP1009.md
+++ b/DIPs/accepted/DIP1009.md
@@ -3,8 +3,8 @@
 | Field             | Value                                                           |
 |-------------------|-----------------------------------------------------------------|
 | DIP:              | 1009                                                            |
-| Review Count:     | 3                                                 |
-| Author:           | Zach Tollen(reachzach@gmail.com)                                |
+| Review Count:     | 3                                                               |
+| Author:           | Zach Tollen(reachzach@gmail.com)                                |
 | Implementation:   | [Timon Gehr]                                                    |
 | Status:           | Accepted                                                        |
 
@@ -275,81 +275,71 @@ The grammar for `assert` arguments is redefined in terms of `ContractArguments`,
 Existing statement-based `in`, `out` and `invariant` contracts are preserved (with the same semantics).
 However, in contrast to before, multiple `in` and `out` contracts are now allowed on the same function declaration, even if they are statement-based.
 
-Changed grammar rules:
-```
-- AssertExpression:
+Grammar changes:
+
+```diff
+AssertExpression:
 -    assert ( AssignExpression ,[opt] )
 -    assert ( AssignExpression , AssignExpression ,[opt] )
++    assert ( ContractArguments )
 
-- FunctionContracts:
+FunctionContracts:
 -     InStatement OutStatement[opt]
 -     OutStatement InStatement[opt]
++     FunctionContract
++     FunctionContract FunctionContracts
 
-- FunctionBody:
+FunctionBody:
 -     BlockStatement
 -     FunctionContracts[opt] BodyStatement
 -     FunctionContracts
++     SpecifiedFunctionBody
++     MissingFunctionBody
 
-- FunctionLiteralBody:
+FunctionLiteralBody:
 -     BlockStatement
 -     FunctionContracts[opt] BodyStatement
++     SpecifiedFunctionBody
 
-- Invariant:
+Invariant:
 -     invariant ( ) BlockStatement
 -     invariant BlockStatement
-
++     invariant ( ) BlockStatement
++     invariant BlockStatement
++     invariant ( ContractArguments ) ;
 
 + ContractArguments:
 +     AssignExpression ,[opt]
 +     AssignExpression , AssignExpression ,[opt]
 
-+ AssertExpression:
-+     assert ( ContractArguments )
-
-+ InExpression:
++ InContractExpression:
 +     in ( ContractArguments )
 
-+ OutExpression:
++ OutContractExpression:
 +     out ( ; ContractArguments )
 +     out ( Identifier ; ContractArguments )
 
-+ InOutExpression:
-+     InExpression
-+     OutExpression
++ InOutContractExpression:
++     InContractExpression
++     OutContractExpression
 
 + InOutStatement:
 +     InStatement
 +     OutStatement
 
 + FunctionContract:
-+     InOutExpression
++     InOutContractExpression
 +     InOutStatement
 
-+ FunctionContracts:
-+     FunctionContract
-+     FunctionContract FunctionContracts
-
 + SpecifiedFunctionBody:
-+     do[OPT] BlockStatement
-+     FunctionContracts[opt] InOutExpression do[OPT] BlockStatement
++     do[opt] BlockStatement
++     FunctionContracts[opt] InOutContractExpression do[opt] BlockStatement
 +     FunctionContracts[opt] InOutStatement do BlockStatement
 
 + MissingFunctionBody:
 +     ;
-+     FunctionContracts[opt] InOutExpression ;
++     FunctionContracts[opt] InOutContractExpression ;
 +     FunctionContracts[opt] InOutStatement
-
-+ FunctionBody:
-+    SpecifiedFunctionBody
-+    MissingFunctionBody
-
-+ FunctionLiteralBody:
-+     SpecifiedFunctionBody
-
-+ Invariant:
-+     invariant ( ) BlockStatement
-+     invariant BlockStatement
-+     invariant ( ContractArguments ) ;
 ```
 
 ## Code Breakage


### PR DESCRIPTION
This commit,

- fixes the issue (https://issues.dlang.org/show_bug.cgi?id=19062)
- ~~makes the DIP more readable (using diff syntax highlighting)~~ 
- fixes non standard blank characters in the table at the top