### PR TITLE
Fix a likely typo in `.alignof`

### DIFF
--- a/DIPs/DIP1017.md
+++ b/DIPs/DIP1017.md
@@ -57,7 +57,7 @@ Properties of `Tbottom`:
 ```d
 Tbottom.mangleof == "??";
 Tbottom.sizeof == 0;
-Tbottom.alignsize == 1;
+Tbottom.alignof == 1;
 ```
 
 Type construction:


### PR DESCRIPTION
This typo was mentioned two times in the final review, without any reply. Nobody believes that a new type property will be added without explanations about the semantic, but just in case of, I use this channel of communication to get a confirmation about the fact that it's **well** a typo.

Thanks.