### PR TITLE
Editorial pass

### DIFF
--- a/DIPs/accepted/DIP1018.md
+++ b/DIPs/accepted/DIP1018.md
@@ -59,7 +59,7 @@ struct A
     immutable int a;
     this(this)
     {
-        this.a += 2;  // modifying immutable error or OK?
+        this.a += 2;  // modifying immutable, an error or OK?
     }
 }
 
@@ -68,7 +68,7 @@ struct B
     A a;
     this(this)
     {
-        this.a.a += 2;  // modifying immutable error or OK?
+        this.a.a += 2;  // modifying immutable, an error or OK?
     }
 }
 

--- a/DIPs/accepted/DIP1018.md
+++ b/DIPs/accepted/DIP1018.md
@@ -10,24 +10,7 @@
 
 ## Abstract
 
-This document proposes copy constructor semantics as an alternative
-to the design flaws and inherent limitations of the postblit.
-
-### Reference
-
-* [1] https://github.com/dlang/dmd/pull/8032
-
-* [2] https://forum.dlang.org/post/p9p64v$ue6$1@digitalmars.com
-
-* [3] http://en.cppreference.com/w/cpp/language/copy_constructor
-
-* [4] https://dlang.org/spec/struct.html#struct-postblit
-
-* [5] https://news.ycombinator.com/item?id=15008636
-
-* [6] https://dlang.org/spec/struct.html#struct-constructor
-
-* [7] https://dlang.org/spec/struct.html#field-init
+This document proposes the copy constructor, an alternative to the postblit function. The copy constructor obviates the need for postblit and fixes its flaws and inherent limitations. Evolution and backward compatibility are also discussed.
 
 ## Contents
 * [Rationale and Motivation](#rationale-and-motivation)
@@ -39,13 +22,11 @@ to the design flaws and inherent limitations of the postblit.
 
 This section highlights the existing problems with the postblit and demonstrates
 why the implementation of a copy constructor is more desirable than an attempt
-to resolve all the postblit issues.
+to fix postblit's issues on a case basis.
 
-### Overview of this(this)
+### Overview of `this(this)`
 
-The postblit function is a non-overloadable, non-qualifiable
-function. However, the compiler does not reject the
-following code:
+The postblit is a function that cannot be meaningfully overloaded or qualified. However, the compiler does not reject certain applications of qualifiers, as illustrated below:
 
 ```D
 struct A { this(this) const {} }
@@ -53,21 +34,23 @@ struct B { this(this) immutable {} }
 struct C { this(this) shared {} }
 ```
 
-Since the semantics of the postblit in the presence of qualifiers is
-not defined and most likely not intended, a series of problems has arisen:
+The semantics of the postblit in the presence of qualifiers is
+not defined, and experimentation reveals that the behavior is a patchwork of happenstance semantics:
 
 * `const` postblits are not able to modify any fields in the destination
 * `immutable` postblits never get called (resulting in compilation errors)
 * `shared` postblits cannot guarantee atomicity while blitting the fields
 
-#### `const`/`immutable` postblits
+Defining and implementing some meaningful semantics will break code that has been tested and deemed correct under the current semantics.
 
-The solution for `const` and `immutable` postblits is to type check them as normal
-constructors, where the first assignment of a member is treated as an initialization
-and subsequent assignments are treated as modifications. This is problematic because
+#### Considering `const`/`immutable` postblits
+
+A solution for `const` and `immutable` postblits would be to type check them as normal
+constructors, where the first assignment of a member is considered an initialization
+and subsequent assignments count as modifications. This is problematic because
 after the blitting phase, the destination object is no longer in its initial state
 and subsequent assignments to its fields will be regarded as modifications, making
-it impossible to construct `immutable`/`const` objects in the postblit. In addition,
+it impossible to construct nontrivial `immutable`/`const` objects in the postblit. In addition,
 it is possible for multiple postblits to modify the same field. Consider:
 
 ```D
@@ -76,7 +59,7 @@ struct A
     immutable int a;
     this(this)
     {
-        this.a += 2;  // modifying immutable or ok?
+        this.a += 2;  // modifying immutable error or OK?
     }
 }
 
@@ -85,7 +68,7 @@ struct B
     A a;
     this(this)
     {
-        this.a.a += 2;  // modifying immutable error or ok?
+        this.a.a += 2;  // modifying immutable error or OK?
     }
 }
 
@@ -102,18 +85,18 @@ When `B c = b;` is encountered, the following actions are taken:
 2. A's postblit is called
 3. B's postblit is called
 
-After `step 1`, the object `c` has the exact contents as `b`, but it is not
-initialized (the postblits still need to fix it) nor uninitialized (the field
+After step 1, the object `c` has the exact contents as `b`, but it is neither
+initialized (the postblits still need to run) nor uninitialized (the field
 `B.a` does not have its initial value). From a type checking perspective
-this is a problem, because the assignment inside A's postblit is breaking immutability.
+this is a problem because the assignment inside `A`'s postblit is breaking immutability.
 This makes it impossible to postblit objects that have `immutable`/`const` fields.
-To alleviate this problem we can consider that after the blitting phase the object is
+To alleviate this problem one could consider that after the blitting phase the object is
 in a raw state, therefore uninitialized; this way, the first assignment of `B.a.a`
 is considered an initialization. However, after this step the field
-`B.a.a` is considered initialized, therefore how is the assignment inside B's postblit
-supposed to be type checked ? Is it breaking immutability or should
+`B.a.a` is considered initialized, therefore how is the assignment inside `B`'s postblit
+supposed to be type checked? Is it a violation of immutability, or should
 it be legal? Indeed, it is breaking immutability because it is changing an immutable
-value. However as this is part of initialization (remember that `c` is initialized only
+value. However as this is part of initialization (recall that `c` is initialized only
 after all the postblits are ran) it should be legal, thus weakening the immutability
 concept and creating a different strategy from that implemented by normal constructors.
 
@@ -140,21 +123,21 @@ void fun()
 ```
 
 Let's consider the above code is run in a multithreaded environment
-When `A b = a;` is encountered, the following actions are taken:
+When `A b = a;` is executed, the following actions are carried:
 
-* `a`'s fields are copied to `b`
-* the user code defined in `this(this)` is called
+* `a`'s fields are copied to `b` bitwise ("blited")
+* `this(this)` is called
 
 In the blitting phase, no synchronization mechanism is employed, which means
-that while the copying is in progress, another thread may modify `a`'s data, resulting
+that while copying is in progress, another thread may modify `a`'s data, resulting
 in the corruption of `b`. There four possible approaches to fixing this issue:
 
-1. Make shared objects larger than two words uncopyable. This solution cannot be
+1. Make `shared` objects larger than two words noncopyable. This solution cannot be
 taken into account because it imposes a major arbitrary limitation: almost all
-`struct`s will become uncopyable.
+`struct`s would become noncopyable.
 
 2. Allow incorrect copying and expect that the user will
-do the necessary synchronization. Example:
+do the necessary synchronization from the outside. Example:
 
 ```D
 shared struct A
@@ -176,50 +159,47 @@ void fun()
 }
 ```
 
-Although this solution solves our synchronization problem, it does so in a manner
-that requires unencapsulated attention at each copy site. Another problem is
-represented by the fact that the mutex release occurs after the postblit is
-run, which imposes some overhead. The release may occur immediately following
+Although this solution solves the synchronization problem, it does so in a manner
+that requires unencapsulated attention at each copy site. A distinct performance problem is
+created by releasing the mutex after the postblit is
+run, which increases the amount of work in the critical section. The release should at best occur immediately following
 the blitting phase (the first line of the postblit) because the copy is
 thread-local, but this results in non-scoped locking: the mutex is released
 in a different scope than that in which it was acquired. Also, the mutex is
-automatically (wrongfully) copied.
+automatically (and wrongfully) copied.
 
-3. Introduce a preblit function that will be called before blitting the fields.
+3. Introduce a preblit function that would be called before blitting the fields.
 The purpose of the preblit is to offer the possibility of preparing data
-before the blitting phase; acquiring the mutex on the `struct` that will be
-copied is one of the operations that the preblit will be responsible for. Later
-on, the mutex will be released in the postblit. This approach has the benefit of
-minimizing the mutex-protected area in a manner that offers encapsulation, but
+before the blitting phase; acquiring the mutex on the `struct` to
+copy is one of the operations that the preblit would be responsible for. Later
+on, the mutex would be released in the postblit. This approach has the benefit of
+minimizing the critical section in a manner that offers encapsulation, but
 suffers the disadvantage of adding even more complexity by introducing a new
 concept which requires type checking disparate sections of code (need to type check
-across preblit, `mempcy` and postblit).
+across preblit, blit, and postblit).
 
 4. Use an implicit global mutex to synchronize the blitting of fields. This approach
 has the advantage that the compiler will do all the work and synchronize all blitting
 phases (even if the threads don't actually touch each other's data) at a cost to
-performance. Python implements a global interpreter lock which was proven to cause
-unscalable high contention; there are ongoing discussions of removing it from the Python
+performance. Python implements a global interpreter lock which is criticized for its
+nonscalable high contention; there are ongoing discussions of removing it from the Python
 implementation [5].
 
 ### Introducing the copy constructor
 
-As stated above, the fundamental problem with the postblit is the automatic blitting
-of fields, which makes type checking impossible and cannot be synchronized without
-additional costs.
+As discussed above, the postblit is difficult to type check without unreasonable restrictions and cannot be synchronized without undue costs.
 
-As an alternative, this DIP proposes the implementation of a copy constructor. The benefits
-of this approach are the following:
+This DIP proposes a copy constructor with the following benefits:
 
-* it is a known concept. C++ has it [3];
-* it can be type checked as a normal constructor (since no blitting is done, the data are
-initialized as if they were in a normal constructor); this means that `const`/`immutable`/`shared`
-copy constructors will be type checked exactly as their analogous constructors
-* offers encapsulation
+* the feature is used to good effect in the C++ language [3];
+* the copy constructor can be type checked as a normal constructor (since no blitting is done, the fields are
+initialized the same as in a normal constructor); this means that `const`/`immutable`/`shared`
+copy constructors will be type checked exactly as their analogous regular constructors;
+* offers encapsulation.
 
 The downside of this solution is that the user must copy all fields by hand, and every
-time a field is added to a `struct`, the copy constructor must be modified. However, this
-can be easily bypassed by D's introspection mechanisms. For example, this simple code
+time a field is added to a `struct`, the copy constructor must be modified. However, this issue
+can be easily worked around by using D's introspection mechanisms. For example, this simple code
 may be used as a language idiom or library function:
 
 ```D
@@ -227,11 +207,8 @@ foreach (i, ref field; src.tupleof)
     this.tupleof[i] = field;
 ```
 
-As shown above, the single benefit of the postblit can be easily substituted with a
-few lines of code. On the other hand, to fix the limitations of the postblit it is
-required that more complexity be added for little to no benefit. In these circumstances,
-for the sake of uniformity and consistency, replacing the postblit constructor with a
-copy constructor is a reasonable approach.
+As shown above, the benefit of the postblit can be easily substituted with a
+few lines of code. As discussed in detail below, copy constructors offer solutions to all of postblit's limitations with minimal increase in language complexity.
 
 ## Description
 
@@ -240,18 +217,16 @@ of the copy constructor.
 
 ### Syntax
 
-A declaration is a copy constructor declaration if it is a constructor declaration that takes only one
-non-default parameter by reference that is of the same type as `typeof(this)`, followed by any number
-of default parameters. Declaring a copy constructor in this manner has the advantage that no parser
-modifications are required, thus leaving the language grammar unchanged.
+Inside a `struct` definition, a declaration is a copy constructor declaration if it is a constructor declaration that takes the first parameter as a nondefaulted reference to the same type as the `struct` being defined. Additional parameters may follow if and only if all have default values. Declaring a copy constructor in this manner has the advantage that no parser
+modifications are required, thus leaving the language grammar unchanged. Example:
 
 ```d
 import std.stdio;
 
 struct A
 {
-    this(ref A rhs) { writeln("x"); }                       // copy constructor
-    this(ref A rhs, int b = 7) immutable { writeln(b)}    // copy constructor with default parameter
+    this(ref A rhs) { writeln("x"); }                     // copy constructor
+    this(ref A rhs, int b = 7) immutable { writeln(b); }  // copy constructor with default parameter
 }
 
 void main()
@@ -263,37 +238,68 @@ void main()
 }
 ```
 
-The copy constructor may also be called explicitly since it is also a constructor.
+The copy constructor may also be called explicitly (as shown above in the line introducing `c`) because it is also a constructor within the preexisting language semantics.
 
 The argument to the copy constructor is passed by reference in order to avoid infinite recursion (passing by
 value would require a copy of the `struct`, which would be made by calling the copy constructor, thus leading
-to an infinite chain of calls).
+to an infinite chain of calls). Note that if the source is an rvalue, no call to the copy constructor is necessary
+because the value will be bitwise moved (if necessary) into the destination. Example:
 
-Type qualifiers may be applied to the parameter of the copy constructor, but also to the function itself,
-in order to facilitate the ability to describe copies between objects of different mutability levels. The type
+```d
+struct A { this(ref A rhs) {} }
+
+A create()
+{
+    static A prototype;
+    return prototype;
+}
+
+void main()
+{
+    A value = create();
+}
+```
+
+Exactly one call to the copy constructor is made, with `prototype` in the `rhs` position. Then the rvalue obtained is seated into `value`.
+
+Type qualifiers may be applied to the parameter of the copy constructor and also to the function itself,
+in order to allow defining copies across objects of different mutability levels. The type
 qualifiers are optional.
 
 ### Semantics
 
 This section discusses all the aspects of the semantic analysis and interaction between the copy
-constructor and other components.
+constructor and other language features.
 
 #### Copy constructor and postblit cohabitation
 
-In order to assure a smooth transition from postblit to copy constructor, the following
-strategy is employed: if a `struct` defines a postblit (user-defined or generated) all
+In order to ensure a smooth transition from postblit to copy constructor, this DIP proposes the
+following strategy: if a `struct` defines a postblit (either user-defined or generated), all
 copy constructor definitions will be ignored for that particular `struct` and the postblit
 will be preferred. Existing code bases that do not use the postblit may start using the
-copy constructor without any problems, while codebases that rely on the postblit may
-start writing new code using the copy constructor and remove the deprecated postblit
-from their code.
+copy constructor, whereas codebases that currently rely on the postblit may
+start writing new code using the copy constructor and remove the postblit
+from their code. This DIP recommends deprecation of postblit but does not prescribe a specific deprecation schedule.
 
-The transition from postblit to copy constructor may be simply achieved by replacing the postblit
-declaration `this(this)` with `this(ref inout(typeof(this)) rhs) inout`.
+A semantically close transition path from postblit to copy constructor may be achieved as follows:
+
+```d
+// Existing code
+struct A
+{
+    this(this) { ... }
+    ...
+}
+// Replacement code
+struct A
+{
+    this(ref inout A rhs) inout { ... }
+}
+```
 
 #### Copy constructor usage
 
-The copy constructor is implicitly used by the compiler whenever a `struct` variable is initialized
+A call to the copy constructor is implicitly inserted by the compiler whenever a `struct` variable is initialized
 as a copy of another variable of the same unqualified type:
 
 1. When a variable is explicitly initialized:
@@ -354,10 +360,8 @@ A gun()
 
 void main()
 {
-    A a;
-    a = fun();      // NRVO - no copy constructor call
-    A b;
-    b = gun();      // NRVO cannot be performed, copy constructor is called
+    A a = fun();      // NRVO - no copy constructor call
+    A b = gun();      // NRVO cannot be performed, copy constructor is called
 }
 ```
 
@@ -380,7 +384,7 @@ A a;
 A fun()
 {
     return a;      // lowered to return tmp.copyCtor(a)
-    // return A();  // rvalue, no copyCtor called
+    // return A(); // rvalue, no copyCtor called
 }
 
 void main()
@@ -470,14 +474,14 @@ void main()
 }
 ```
 
-In the case of partial matching, existing overloading and implicit conversions
-apply to the argument.
+In the case of partial matching, existing overloading and implicit conversion
+rules apply to the argument.
 
 #### Copy constructor call vs. blitting
 
 When a copy constructor is not defined for a `struct`, initializations are handled
 by copying the contents from the memory location of the right-hand side expression
-to the memory location of the left-hand side expression (i.e. "blitting"):
+to the memory location of the left-hand side expression (i.e. "blitting"). Example:
 
 ```d
 struct A
@@ -495,7 +499,7 @@ void main()
 ```
 
 When a copy constructor is defined for a `struct`, all implicit blitting is disabled for
-that `struct`:
+that `struct`. Example:
 
 ```d
 struct A
@@ -515,8 +519,7 @@ void main()
 
 #### Interaction with `alias this`
 
-A `struct` may define both an `alias this` and a copy constructor for which assignments to variables
-of the `struct` type may lead to ambiguities:
+A `struct` that defines both an `alias this` and a copy constructor may engender ambiguous situations. Ambiguity occurs when the type returned by `alias this` is a qualified version of the type being defined. Example:
 
 ```d
 struct A
@@ -542,14 +545,13 @@ struct B
 
     alias fun this;
 
-    this(ref A another) {}
+    this(ref B another) {}
 }
 
 void main()
 {
     A a;
     immutable A ia = a;    // copy constructor
-
     B b;
     immutable B ib = b;    // error: copy constructor may not be called for argument types `() immutable`
 }
@@ -559,17 +561,16 @@ When both the copy constructor and `alias this` are suitable to resolve the
 assignment, the copy constructor takes precedence over `alias this` as it is
 considered more specialized (the sole purpose of the copy constructor is to
 create copies). If no copy constructor in the overload set is matched, an error
-is issued, even though an `alias this` might be used to resolve the assignment.
+is issued, even if using `alias this` could theoretically lead to a matching constructor. In other words, `alias this` is intentionally ignored for all purposes of copy construction.
 
 #### Generating copy constructors
 
-A copy constructor is generated implicitly by the compiler for a `struct S` if:
+A copy constructor is generated implicitly by the compiler for a `struct S` if all of the following conditions are met:
 
-1. `S` does not define any copy constructors;
-2. `S` does not have an overlapping field that defines a copy constructor;
-3. `S` defines at least one member that has a copy constructor.
+1. `S` does not explicitly declare any copy constructors;
+2. `S` defines at least one direct member that has a copy constructor, and that member is not overlapped (by means of `union`) with any other member.
 
-If all of the restrictions above are met, the following copy constructor is generated:
+If the restrictions above are met, the following copy constructor is generated:
 
 ```d
 this(ref inout(S) src) inout
@@ -581,7 +582,7 @@ this(ref inout(S) src) inout
 
 ### Plain Old Data (POD)
 
-A `struct` that defines a copy constructor is not POD.
+A `struct` that defines a copy constructor is not a POD.
 
 ### Interaction with unions
 
@@ -612,11 +613,27 @@ void main()
 }
 ```
 
-A solution to this might be to make the reference `const`, but that would make code like
-`this.a = another.a` inside the copy constructor illegal. This can be solved with a cast, e.g.
-`this.a = cast(int[])another.a`.
+This is surprising and potentially error-prone behavior because changing the source of a copy is not customary and may surprise the user of a type. (For that reason, C++ coding standards adopt the convention of taking the source by means of reference to `const`; copy constructors that use non-`const` right-hand side are allowed but discouraged.) In D, `const` and `immutable` are more restrictive than in C++, so forcing `const` on the copy constructor's right-hand side would make simple copying task unduly difficult. Consider:
 
-2. This DIP changes the semantics of constructors which receive a parameter by reference of type
+```d
+class Window
+{
+    ...
+}
+struct Widget
+{
+    private Window display;
+    ...
+    this(ref const Widget rhs)
+    {
+        display = rhs.display; // Error! Cannot initialize a Window from a const(Window)
+    }
+}
+```
+
+Such sharing of resources across objects is a common occurrence, which would be impeded by forcing `const` on the right-hand side of a copy. (An inferior workaround would be to selectively cast `const` away inside the copy constructor, which is obviously undesirable.) For that reason this DIP proposes allowing mutable copy sources.
+
+2. This DIP changes the semantics of constructors that receive a parameter by reference of type
 `typeof(this)`. The consequence is that existing constructors might be called implicitly in some
 situations:
 
@@ -639,15 +656,31 @@ void main()
 }
 ```
 
-This will print "Yo" subsequent to the implementation of this DIP, where before it printed nothing. A case can be
+This will print `"Yo"` subsequent to the implementation of this DIP, whereas under the current semantics it prints nothing. A case can be
 made that a constructor with the above definition could not be correctly used as anything else than a copy
-constructor, in which case this DIP  actually fixes the code.
+constructor, in which case this DIP actually fixes the code.
 
 ## Copyright & License
 
 Copyright (c) 2018 by the D Language Foundation
 
 Licensed under [Creative Commons Zero 1.0](https://creativecommons.org/publicdomain/zero/1.0/legalcode.txt)
+
+### References
+
+* [1] https://github.com/dlang/dmd/pull/8032
+
+* [2] https://forum.dlang.org/post/p9p64v$ue6$1@digitalmars.com
+
+* [3] http://en.cppreference.com/w/cpp/language/copy_constructor
+
+* [4] https://dlang.org/spec/struct.html#struct-postblit
+
+* [5] https://news.ycombinator.com/item?id=15008636
+
+* [6] https://dlang.org/spec/struct.html#struct-constructor
+
+* [7] https://dlang.org/spec/struct.html#field-init
 
 ## Reviews
 


### PR DESCRIPTION
This pass works on the prose without changing the semantics. I've added it in response to requests that the DIP is improved to better explain the use of mutable references on the right-hand side.