### PR TITLE
Add return ref to copy constructor parameter

### DIFF
--- a/DIPs/DIP1018.md
+++ b/DIPs/DIP1018.md
@@ -250,8 +250,8 @@ import std.stdio;
 
 struct A
 {
-    this(ref A rhs) { writeln("x"); }                       // copy constructor
-    this(ref A rhs, int b = 7) immutable { writeln(b)}    // copy constructor with default parameter
+    this(ref return scope A rhs) { writeln("x"); }                       // copy constructor
+    this(ref return scope A rhs, int b = 7) immutable { writeln(b)}    // copy constructor with default parameter
 }
 
 void main()
@@ -301,7 +301,7 @@ as a copy of another variable of the same unqualified type:
 ```d
 struct A
 {
-    this(ref A rhs) {}
+    this(ref return scope A rhs) {}
 }
 
 void main()
@@ -317,7 +317,7 @@ void main()
 ```d
 struct A
 {
-    this(ref A another) {}
+    this(ref return scope A another) {}
 }
 
 void fun(A a) {}
@@ -334,7 +334,7 @@ void main()
 ```d
 struct A
 {
-    this(ref A another)
+    this(ref return scope A another)
     {
         writeln("cpCtor");
     }
@@ -373,7 +373,7 @@ may be performed, then the copy is elided:
 ```d
 struct A
 {
-    this(ref A rhs) {}
+    this(ref return scope A rhs) {}
 }
 
 A a;
@@ -399,8 +399,8 @@ Copy constructor overloads can be explicitly disabled:
 ```d
 struct A
 {
-    @disable this(ref A rhs);
-    this(ref immutable A rhs) {}
+    @disable this(ref return scope A rhs);
+    this(ref immutable return scope A rhs) {}
 }
 
 void main()
@@ -427,10 +427,10 @@ destination):
 ```d
 struct A
 {
-    this(ref A another) {}                        // 1 - mutable source, mutable destination
-    this(ref immutable A another) {}              // 2 - immutable source, mutable destination
-    this(ref A another) immutable {}              // 3 - mutable source, immutable destination
-    this(ref immutable A another) immutable {}    // 4 - immutable source, immutable destination
+    this(ref return scope A another) {}                        // 1 - mutable source, mutable destination
+    this(ref return scope immutable A another) {}              // 2 - immutable source, mutable destination
+    this(ref return scope A another) immutable {}              // 3 - mutable source, immutable destination
+    this(ref return scope immutable A another) immutable {}    // 4 - immutable source, immutable destination
 }
 
 void main()
@@ -454,7 +454,7 @@ treated the same:
 ```d
 struct A
 {
-    this(ref inout A rhs) immutable {}
+    this(ref return scope inout A rhs) immutable {}
 }
 
 void main()
@@ -501,7 +501,7 @@ that `struct`:
 struct A
 {
     int[] a;
-    this(ref A rhs) {}
+    this(ref return scope A rhs) {}
 }
 
 void fun(immutable A) {}
@@ -529,7 +529,7 @@ struct A
 
     alias fun this;
 
-    this(ref A another) immutable {}
+    this(ref return scope A another) immutable {}
 }
 
 struct B
@@ -542,7 +542,7 @@ struct B
 
     alias fun this;
 
-    this(ref A another) {}
+    this(ref return scope A another) {}
 }
 
 void main()
@@ -572,7 +572,7 @@ A copy constructor is generated implicitly by the compiler for a `struct S` if:
 If all of the restrictions above are met, the following copy constructor is generated:
 
 ```d
-this(ref inout(S) src) inout
+this(ref return scope inout(S) src) inout
 {
     foreach (i, ref inout field; src.tupleof)
         this.tupleof[i] = field;
@@ -599,7 +599,7 @@ the source object:
 struct A
 {
     int[] a;
-    this(ref A another)
+    this(ref return scope A another)
     {
         another.a[2] = 3;
     }
@@ -623,7 +623,7 @@ situations:
 ```d
 struct C
 {
-    this(ref C another)    // normal constructor before DIP, copy constructor after
+    this(ref return scope C another)    // normal constructor before DIP, copy constructor after
     {
         import std.stdio : writeln;
         writeln("Yo");


### PR DESCRIPTION
It is not mandatory, but good practice.