### PR TITLE
[1013] Make changes per Walter and Andrei's feedback.

### DIFF
--- a/DIPs/DIP1013.md
+++ b/DIPs/DIP1013.md
@@ -1,19 +1,19 @@
 # The Deprecation Process
 
-| Field           | Value                                                           |
-|-----------------|-----------------------------------------------------------------|
-| DIP:            | 1013                                                            |
-| Review Count:   | 2                                                               |
-| Author:         | Jack Stouffer <jack@jackstouffer.com>                           |
-| Implementation: | N/A                                                             |
-| Status:         | Formal Assessment                                               |
+| Field           | Value                                                                           |
+|-----------------|---------------------------------------------------------------------------------|
+| DIP:            | 1013                                                                            |
+| Review Count:   | 3                                                                               |
+| Author:         | Jack Stouffer <jack@jackstouffer.com>, Jonathan M Davis jmdavis@jmdavisprog.com |
+| Implementation: | N/A                                                                             |
+| Status:         | Formal Assessment                                                               |
 
 ## Abstract
 
 In order to incrementally improve D or it's standard library, it's often necessary to
 mark features or functions for future removal. This document proposes a standardized
 process for language maintainers to remove public features. This process would be
-used across DMD, Druntime, and Phobos.
+used across dmd, druntime, and phobos.
 
 ## Contents
 * [Rationale](#rationale)
@@ -21,6 +21,7 @@ used across DMD, Druntime, and Phobos.
 * [Description](#description)
     * [Public Functions, Types, and Modules](#public-functions-types-and-modules)
     * [Language Features](#language-features)
+* [Summary of the Steps in the Normal Deprecation Process](#Summary-of-the-Steps-in-the-Normal-Deprecation-Process)
 * [Copyright & License](#copyright--license)
 * [Reviews](#reviews)
 
@@ -32,102 +33,182 @@ who's writing the pull request. Standardizing the process makes sure that
 deprecations are done very publicly and carefully, so as to minimize breakage and
 to provide clear fixes for user code.
 
-## Terminology
-
-Whenever an upper case vowel is used (MAY, SHOULD, MUST NOT), their meaning should be
-taken as defined in [RFC 2119](https://tools.ietf.org/html/rfc2119).
-
 ## Description
 
-The following lays out a new procedure for deprecating a part of D.
+The following lays out the normal procedure for deprecating a part of D. It is
+roughly the procedure that has been followed with phobos for several years, but
+this formalizes and clarifies it with some minor modifications.
 
-A symbol or feature MUST NOT be marked for removal on a specific date, but rather on a
-specific release. This allows users to easily determine if upgrading will break their
-code.
+In the normal case, users should be given at least 10 non-patch releases before
+a deprecated feature or symbol is removed. This gives users time to update
+their code without forcing them to do so ASAP while still not leaving
+deprecated features or symbols around long term.
 
-Users MUST be given at least 10 non-patch releases before the deprecated features
-are removed. More releases can be given if the removed code is commonly used.
-There are two cases where the deprecation period MAY be shorter:
+More releases can be given if deemed appropriate. In particular, if a feature
+or symbol has been around for a long time and is heavily used, then it may make
+sense to leave it around longer. In such cases, the feature or symbol should
+probably be undocumented within approximately the normal deprecation period of
+10, non-patch releases in order to reduce the likelihood of new code using it.
+However, in general, deprecated features and symbols should not be left around
+long term (let alone permanently), because it results in a maintenance burden
+on the maintainers of any D compilers and the standard library. It also makes
+it more likely that the feature or symbol will continue to be used long beyond
+the point that it would ideally no longer be used, and in some cases, it can
+actively prevent new features or symbols from being added. Ideally, deprecated
+features and symbols would be removed from the language or standard library in
+a timely manner so that they no longer need to be maintained, and D programmers
+no longer need to deal with them in any code bases that they work on. So,
+keeping deprecated features or symbols around long term should only be done in
+more exceptional cases.
 
-1. The code or feature is notably dangerous or unsafe, and users need to remove
-it from their code as soon as possible.
-2. The existence of the current code precludes its own fix or the fix of an equally
-important issue.
+Similarly, if deemed appropriate, a symbol may be undocumented but not
+immediately deprecated, but that should only be done in exceptional cases for
+the same reason that symbols would ideally not remain deprecated for long
+periods of time without being removed. It also has the additional problem that
+as long as the symbol isn't actually deprecated, it's unlikely that existing
+code will be updated to no longer use it, and if it's undocumented before it's
+deprecated, then it will be harder for anyone to know how to update their code.
+So, while it may make sense in rare cases, there needs to be a solid reason for
+deviating from the normal procedure.
 
-Shortening the deprecation period SHOULD be done with caution to avoid giving D
-an image of instability.
+If deemed appropriate, the deprecation process can be shorter than 10
+non-patch releases, but under normal circumstances, it shouldn't be, because
+removing features or symbols too quickly can introduce a maintenance burden on
+anyone using those features or symbols, and it potentially gives D the image of
+instability. Two cases where it would make sense for the deprecation period to
+be shorter would be
 
-The restriction to at least 10 non-patch releases is made with the asumption that
-releases are made frequently enough that this will result in a deprecation period
-of about two years. A change in release scheduling MUST be accompanied with a
-modification of this document to bring the number of releases in-line with a
-roughly two year cycle.
+1. If it is determined that leaving the feature or symbol in the language or
+   library does sufficient harm that it needs to be removed from use as quickly
+   as possible (one example of this would be "accepts-invalid" bug fixes).
+2. The existence of the current code precludes its own fix or the fix of an
+   equally important issue.
 
-At the time of the pull request for deprecation, all code in Phobos, Druntime,
-and DMD MUST be updated to remove use of the effected code. Maintainers of any
-projects which are tested on the Project Tester and are broken by the deprecation
-SHOULD be notified.
+The restriction to at least 10 non-patch releases is made with the asumption
+that releases are made frequently enough that this will result in a deprecation
+period of about two years (which is the time period that has been used with
+phobos for several years now). A change in release scheduling should be
+accompanied with a modification of this document to bring the number of
+releases in line with a roughly two year cycle.
 
-Both at the time of deprecation and removal, a changelog entry MUST be made. This
-changelog entry SHOULD have a short motivation for the deprecation (or removal)
-and should describe which steps can be taken by the user to upgrade their codebase.
+In the documentation, a symbol or feature should be marked for removal on a
+specific release (e.g. 2.091) rather than a specific date (historically, phobos
+has used specific dates rather than releases but has been moving to using
+releases). Using specific releases is preferable, because it allows users to
+easily determine if upgrading will break their code, whereas release dates tend
+to only work well when always using the latest release.
+
+At the time of the pull request for deprecation, all code in phobos, druntime,
+and dmd should be updated to remove use of the effected code (or be deprecated
+if appropriate - e.g. the tests for a deprecated feature would be deprecated
+rather than removed). In the case of druntime and phobos, this is currently
+enforced by their makefiles. Maintainers of any projects which are tested on
+the Project Tester and are broken by the deprecation should be notified.
+
+Both at the time of deprecation and removal, a changelog entry must be made.
+This changelog entry should have a short motivation for the deprecation (or
+removal) and should describe which steps can be taken by the user to upgrade
+their codebase.
 
 In order to facilitate on schedule deprecations, a comment of the format
-`@@@DEPRECATED_[version]@@@` SHOULD be added to the top of the code to be removed/disabled.
-This comment allows code to be easily searched before every release to
-find all planned deprecations.
+`@@@DEPRECATED_[version]@@@` should be added to the top of the code to be
+removed/disabled where the verison number is the version where the feature will
+be fully removed from the language or standard library. This comment allows
+code to be easily searched before every release to find all planned
+deprecations.
 
 ### Public Functions, Variables, Types, and Modules
 
 All removals or changes to protection attributes of public functions,
-variables, types, and modules MUST be accompanied with a deprecation period.
+variables, types, and modules should be accompanied with a deprecation period
+so as to avoid immediately breaking existing code.
 
-The symbol(s) MUST be marked using the `deprecated` keyword with a message containing
-the planned release that the symbol will be removed in. A reference to more information
-should also be added. E.g. "See the 2.080 changelog for more details" or "See the function
-documentation for more details". The documentation of the symbol(s) MUST be updated noting the
-deprecation and removal plan. The documentation SHOULD contain information to help
-the users of the symbol(s) transition their code away from the symbol(s).
+The symbol(s) should be marked using the `deprecated` keyword with a message
+containing the planned release that the symbol will be removed in. A reference
+to more information should also be added. E.g. "See the 2.080 changelog for
+more details" or "See the function documentation for more details". The
+documentation of the symbol(s) should be updated noting the deprecation and
+removal plan. The documentation should contain information to help the users of
+the symbol(s) transition their code away from the symbol(s).
 
 If the deprecation is occurring because the symbol(s) are being replaced by new
-symbols, both the old and the new symbol(s) MUST be available without a
+symbols, both the old and the new symbol(s) must be available without a
 deprecation message in at least one release to allow users to build their code
-without issue on both the `stable` and `master` branches.
+without issue on both the `stable` and `master` branches. It has caused
+problems in the past when symbols in phobos were immediately deprecated when
+their replacements were added precisely because prominent projects such as
+dustmite make sure that they work with both the `stable` and `master` branches.
 
-On the first release in the deprecation period, the removed symbol(s) SHOULD
-be removed from any module or package wide list of public functions/booktables/cheatsheets
-to deemphasize its use. On the fifth release in the deprecation period, the documentation
-for the symbol MUST be removed completely while keeping the code itself public until
-complete removal.
+Halfway through the deprecation period (so, normally after the symbol has been
+deprecated for five releases), documentation for the symbol should be removed
+completely while keeping the code itself public until complete removal in order
+to make it less likely that new code will be written that uses the deprecated
+symbol.
 
 If there is no equivalent for the functionality of the removed symbol in the
-standard library or the runtime, the code MUST be moved to
-[undeaD](https://github.com/dlang/undeaD) to allow users to keep their current
-code if refactoring is not possible.
+standard library or the runtime, then when the symbol is deprecated, the code
+should be added to [undeaD](https://github.com/dlang/undeaD) to allow users to
+keep their current code if refactoring is not possible.
 
 ### Language Features
 
-Unless the removed language feature is very unsafe or causes damage to real
-world systems, all changes or removals MUST be accompanied with a deprecation
-period. "Language features" includes bugs in the current behavior upon which
-existing code depends, e.g. [Issue 10378](https://issues.dlang.org/show_bug.cgi?id=10378).
-Fixing such issues MUST include a deprecation period for the current behavior,
-and an introduction of the new behavior as the default only at the end of the
+Under normal circumstances, the removal of a language feature should be
+accompanied with a deprecation period. "Language features" includes bugs in the
+current behavior upon which existing code depends, e.g. [Issue
+10378](https://issues.dlang.org/show_bug.cgi?id=10378). Fixing such issues
+should include a deprecation period for the current behavior and an
+introduction of the new behavior as the default only at the end of the period.
+If the D leadership determines that a change is critical enough to be
+implemented immediately, then of course, it can be implemented immediately, but
+in general, breaking changes should involve a deprecation period in order to
+avoid causing serious problems for existing D projects or giving the impression
+that D is unstable. Whether an "accepts-invalid" bug should include a
+deprecation period depends on the nature of the bug and the impact of the
+change, but in general, they should be fixed immediately without a deprecation
 period.
 
-Deprecations to language features MUST also update the [language deprecations page](https://dlang.org/deprecate.html) on dlang.org simultaneously. The deprecation
-message given by the compiler SHOULD contain the planned removal period and/or a
-reference to more information pertaining to the deprecation.
+Deprecations to language features must also update the [language deprecations
+page](https://dlang.org/deprecate.html) on dlang.org simultaneously. The
+deprecation message given by the compiler should contain the planned removal
+period and/or a reference to more information pertaining to the deprecation.
 
-Warnings MUST NOT be used in the deprecation process. Warnings are set as errors
-in many build systems (including DUB), and would therefore prematurely break many
-user's code. The exception is when a change deprecates a feature which is intended
-to turn something into a warning. In this case the code which would trigger the
-warning must also first go through a deprecation period.
+Warnings should not be used in the deprecation process. Warnings are set as
+errors in many build systems (including dub), and would therefore prematurely
+break many user's code. The exception is when a change deprecates a feature
+which is intended to turn something into a warning. In this case, the code
+which would trigger the warning must also first go through a deprecation
+period.
+
+## Summary of the Steps in the Normal Deprecation Process
+
+### Steps at the time of deprecation
+
+1. Remove all uses of the to-be-deprecated feature/symbol from dmd, druntime,
+   and phobos (unless it's in something that is also being deprecated).
+2. Update the documentation to indicate in which release the feature/symbol will
+   be fully removed as well as give any additional, appropriate information about the
+   deprecation (e.g. what should be used instead). In the case of language
+   changes, this includes updating the [language deprecations
+   page](https://dlang.org/deprecate.html).
+3. Create a changelog entry.
+4. Deprecate the feature/symbol such that a deprecation message is printed that
+   has the release that the feature/symbol will be removed in (and thus will be
+   affected by the `-d`, `-dw`, and `-de` flags).
+
+### After 5 non-patch releases (halfway through the deprecation period)
+
+1. In the case of library symbols, their public documentation should be removed.
+
+### After 10 non-patch releases (at the end the deprecation period)
+
+1. In the case of language features, the spec and the [language deprecations page](https://dlang.org/deprecate.html)
+   need to be updated for the full removal of the feature.
+2. Create a changelog entry.
+3. The feature/symbol should be fully removed.
 
 ## Copyright & License
 
-Copyright (c) 2018 by the D Language Foundation
+Copyright (c) 2018 - 2019 by the D Language Foundation
 
 Licensed under [Creative Commons Zero 1.0](https://creativecommons.org/publicdomain/zero/1.0/legalcode.txt)
 
@@ -139,7 +220,7 @@ Licensed under [Creative Commons Zero 1.0](https://creativecommons.org/publicdom
 
 [Discussion](https://forum.dlang.org/thread/rxlbdijkbhanwvbksuej@forum.dlang.org)
 
-A change was requested in the specification of the deprecation period. The DIP specified the deprecation period as "at least 10 non-patch releases", which, though not mentioned in the DIP, was based on the pace of DMD releases over a two-year period at the time the DIP was authored. It was suggested to change this to "a minimum of two years" to account for future changes to the pace of DMD releases. The DIP author elected to maintain the existing language with the clarification that it is based on a period of two years and that the DIP should be updated with a new two-year release count to reflect any changes in the pace of major DMD releases.
+A change was requested in the specification of the deprecation period. The DIP specified the deprecation period as "at least 10 non-patch releases", which, though not mentioned in the DIP, was based on the pace of dmd releases over a two-year period at the time the DIP was authored. It was suggested to change this to "a minimum of two years" to account for future changes to the pace of dmd releases. The DIP author elected to maintain the existing language with the clarification that it is based on a period of two years and that the DIP should be updated with a new two-year release count to reflect any changes in the pace of major dmd releases.
 
 The DIP specified that deprecated symbols must be annotated with a deprecation message "containing the planned removal period". A request was made to clarify that the meaning of "removal period", i.e. the release in which the symbol is removed from the language vs. the release in which it is removed from the documentation. The author agreed to the change.
 
@@ -156,3 +237,13 @@ The observation was made that the meaning of `version` in `@@@DEPRECATED_[versio
 There one objection to the recommendation that removal of a deprecated symbol from "any module or package wide list of public functions/booktables/cheatsheets", with the explanation that the deprecation notice itself should be enough to discourage use of the deprecated symbol.
 
 A request was made to explicitly outline and describe each stage of the deprecation process in a list in order to make the document easier to read.
+
+### Feedback from Walter and Andrei
+
+[Reviewed Version](https://github.com/dlang/DIPs/commit/6389136159f5bda8df9c21f3c960a58420c0c4b3)
+
+It was requested that the language be less rigid and presented more as guidelines rather than hard and fast rules.
+
+It was requested that the document be more specific about "accepts-invalid" bugs with the note that they should be fixed immediately.
+
+It was requested that the document mention the practice of leaving symbols undocumented long term as some other languages and libraries do.


### PR DESCRIPTION
Hopefully, this adequately addresses Walter and Andrei's feedback. Most of the "must"s have been removed, and while the gist of the procedure is the same, the language is less strict. It also now addresses "accepts-invalid" more clearly. The issue of leaving symbols undocumented is now addressed, though the DIP says that that is not the normal procedure and gives reasons why.