### PR TITLE
[New DIP] Compile-time Indexing Operators

### DIFF
--- a/DIPs/DIP-1NNN-QFS.md
+++ b/DIPs/DIP-1NNN-QFS.md
@@ -156,13 +156,13 @@ unittest
 Tuples can have a varying degree of homo-/heterogeneity:
 * It can be fully homogeneous, i. e. all the entries have exactly the same type, e. g. a tuple of `int` and `int`.
 * It can be unqualified homogeneous, i. e. the unqualified types of the entries are exactly the same type, e. g. a tuple of `int` and `immutable(int)`.
-* It can be class homogeneous in the sense that all the entries are of class type and have a common base; that base class can be `Object` but may be more concrete. This is true only if all of the entries are `shared` or all are not `shared`.[⁽⁵⁾]
+* It can be class homogeneous in the sense that all the entries are of class type and have a common base; that base class can be `Object` but may be more concrete. This is true only if all of the entries are `shared` or all are not `shared`.[⁽³⁾]
 * It can be convertible homogeneous, i. e. there is a type that all entries can be converted to. The selection of the common type could allow user-defined conversions, e. g. setting the common type of `int` and `uint` to `ulong`.
 * It is fully heterogeneous if it is neither of these.
 
 The homogeneity properties can be made use of via Design by Introspection:[⁽⁴⁾]
 * Fully homogeneous tuples are basically static arrays and can be converted by `opIndex` to a slice of the unique underlying type.
-* Unqualified homogeneous tuples can be sliced, too: The types hava a common type using implicit qualifier conversions[⁽⁵⁾] and that type is the underlying type of that slice.
+* Unqualified homogeneous tuples can be sliced, too: The types hava a common type using implicit qualifier conversions[⁽³⁾] and that type is the underlying type of that slice.
 
 ```D
 import sophisticated.tuple : Tuple;
@@ -226,7 +226,7 @@ This is true even if the call to `opIndex` does not compile.
 
 ### Compile-time Random-access Ranges
 
-One can implement some kind of compile-time version of Phobos’ `iota`[⁽⁶⁾] and other ranges.
+One can implement some kind of compile-time version of Phobos’ `iota`[⁽⁵⁾] and other ranges.
 To the outside oberserver, these seem to contain values, but the values are caluclated
 from internal state without creating the values beforehand.
 
@@ -307,7 +307,7 @@ It can be argued that this usage of the static and dynamic indexing operators is
 
 ### Current State
 
-Currently, the only way to mimic indexing is using alias this to a compile-time sequence (generated e. g. by Phobos’ `AliasSeq` template[⁽³⁾]).
+Currently, the only way to mimic indexing is using alias this to a compile-time sequence (generated e. g. by Phobos’ `AliasSeq` template[⁽⁶⁾]).
 In Phobos, `Tuple` does exactly that.[⁽²⁾]
 This has several limitations:
 
@@ -321,7 +321,7 @@ Consequently, Phobos’ `Tuple` when sliced, does not return a `Tuple` but a seq
 3. The sequence cannot be protected from modifications.
 It is fully exposed without any possibility to manage access to it.
 4. The complete sequence must exist in the first place.
-It might be desirable to pretend the existence of a sequence without storing a sequence (cf. Phobos’ `iota`[⁽²⁾]).
+It might be desirable to pretend the existence of a sequence without storing a sequence (cf. Phobos’ `iota`[⁽⁵⁾]).
 5. As alias this is already taken, one cannot alias this something different.
 
 The whole sequence approach can only be used for indexing with exactly one parameter.
@@ -368,26 +368,26 @@ Even then, the change would not actually break that code or change its semantics
 
 <!--- List of references --->
 
-⁽¹⁾ [D Language Specification on Operator Overloading](https://dlang.org/spec/operatoroverloading.html)
+ (1) [D Language Specification on Operator Overloading](https://dlang.org/spec/operatoroverloading.html)
 
-⁽²⁾ [D Library Documentation on std.typecons.Tuple](https://dlang.org/library/std/typecons/tuple.html)
+ (2) [D Library Documentation of std.typecons.Tuple](https://dlang.org/library/std/typecons/tuple.html)
 
-⁽³⁾ [D Library Documentation on std.meta.AliasSeq](https://dlang.org/library/std/meta/alias_seq.html)
+ (3) [D Language Specification on Implicit Qualifier Conversions](https://dlang.org/spec/const3.html#implicit_qualifier_conversions)
 
-⁽⁴⁾ [Alexandrescu at D Language Conference 2017, *Design by Introspection*](https://youtu.be/29h6jGtZD-U)
+ (4) [Andrei Alexandrescu at D Language Conference 2017: *Design by Introspection*](https://youtu.be/29h6jGtZD-U)
 
-⁽⁵⁾ [D Language Specification on Implicit Qualifier Conversions](https://dlang.org/spec/const3.html#implicit_qualifier_conversions)
+ (5) [D Library Documentation of std.range.iota](https://dlang.org/phobos/std_range.html#.iota)
 
-⁽⁶⁾ [D Library Documentation on std.range.iota](https://dlang.org/phobos/std_range.html#.iota)
+ (6) [D Library Documentation of std.meta.AliasSeq](https://dlang.org/library/std/meta/alias_seq.html)
 
 <!--- Markdown reference definitions --->
 
 [⁽¹⁾]: #references "D Language Specification on Operator Overloading"
 [⁽²⁾]: #references "D Library Documentation on std.typecons.Tuple"
-[⁽³⁾]: #references "D Library Documentation on std.meta.AliasSeq"
+[⁽³⁾]: #references "D Language Specification on Implicit Qualifier Conversions"
 [⁽⁴⁾]: #references "D Language Conference 2017, Talk by Andrei Alexandrescu, Design by Introspection"
-[⁽⁵⁾]: #references "D Language Specification on Implicit Qualifier Conversions"
-[⁽⁶⁾]: #references "D Library Documentation on std.range.iota"
+[⁽⁵⁾]: #references "D Library Documentation on std.range.iota"
+[⁽⁶⁾]: #references "D Library Documentation on std.meta.AliasSeq"
 
 ## Copyright & License
 
@@ -399,5 +399,3 @@ Licensed under [Creative Commons Zero 1.0](https://creativecommons.org/publicdom
 
 The DIP Manager will supplement this section with a summary of each review stage
 of the DIP process beyond the Draft Review.
-
-<!---  ’⁰¹²³⁴⁵⁶⁷⁸⁹⁽⁾ --->

--- a/DIPs/DIP-1NNN-QFS.md
+++ b/DIPs/DIP-1NNN-QFS.md
@@ -48,6 +48,10 @@ This is what the compiler does for static arrays:
 While, formally, indexing is a run-time operation, when using a compile-time known index that is out of bounds,
 the compiler will report an error.
 
+It is worth mentioning that this DIP introduces user-defined syntax that changes semantics based on compile-time
+availableness of syntactically identical arguments.
+It can be used to implement functions that are compile-time to some parameters.
+
 ## Description
 
 When a user-defined type has any of the following compiler-recognized members
@@ -74,6 +78,8 @@ The DIP proposes to add the following names to the compiler-recognized member na
 Notably absent is the name `opStaticDollar`.
 The rewrite of `$` remains unchanged,
 as `opDollar` does not require any function parameters.
+There are multiple examples in Phobos defining `opDollar` not by a function,
+but e. g. an `enum`.
 
 The DIP proposes that rewriting indexing expressions as per the spec,[⁽¹⁾]
 the compiler will first try static indexing operators,

--- a/DIPs/DIP-1NNN-QFS.md
+++ b/DIPs/DIP-1NNN-QFS.md
@@ -339,6 +339,14 @@ the same way, meta-programming code does not have to distinguish
 dynamic arrays and user-defined random-access ranges when indexing them.
 The current solution is to ignore tuple-like types or to special-case specific ones.
 
+### Alternative Syntax
+
+If the language maintainers decide that overloading indexing syntax is not desirable,
+the DIP proposes to use the syntax `object![indices]` (note the exclamation mark) for static indexing.
+This syntax is is currently an error and therefore a mere addition to the language.
+Accordingly, indexing compile-time sequences should also be possible to do with the syntax `sequence![index]`
+to cater to meta-programming contexts.
+
 ### Compile-time Function Parameters
 
 If some way to discriminate function parameters for their compile-time availableness were implemented,

--- a/DIPs/DIP-1NNN-QFS.md
+++ b/DIPs/DIP-1NNN-QFS.md
@@ -4,42 +4,42 @@
 |-----------------|-----------------------------------------------------------------|
 | DIP:            | (number/id -- assigned by DIP Manager)                          |
 | Review Count:   | 0 (edited by DIP Manager)                                       |
-| Author:         | Quirin F. Schroll <q.schroll@gmail.com>                         |
+| Author:         | Quirin F. Schroll (q.schroll@gmail.com)                         |
 | Implementation: | (links to implementation PR if any)                             |
-| Status:         | Will be set by the DIP manager (e.g. "Approved" or "Rejected")  |
+| Status:         | Will be set by the DIP manager (e. g. "Approved" or "Rejected") |
 
 ## Abstract
 
 In the current state of the D Programming Language, a user-defined type can only
 define indexing operators with function parameters.
 This DIP proposes additional compiler-recognized member names for implementing indexing
-where the indexing parameters are required to be—or handled differently when—known at compile-time.
+where the indexing parameters are required to be – or handled differently when – known at compile-time.
 
 ## Contents
 * [Rationale](#rationale)
 * [Description](#description)
 * [Alternatives](#alternatives)
 * [Breaking Changes and Deprecations](#breaking-changes-and-deprecations)
-* [Reference](#reference)
+* [References](#references)
 * [Copyright & License](#copyright--license)
 * [Reviews](#reviews)
 
 ## Rationale
 
 Implementing heterogeneous structures like tuples, indexing syntax can only be implemented in a very narrow way
-(cf. [Alternatives](#alternatives): Current State).
+(cf. [Current State Alternatives](#current-state).
 Given a user-defined tuple type, sophisticated indexing would require handling the indexing parameters as
 compile-time values to determine even the type of the indexing expression.
 
 With the additions proposed by this DIP, it would be possible to make
-e.g. slices of Phobos' `Tuple` return a `Tuple` again.
+e. g. slices of Phobos’ `Tuple` return a `Tuple` again.
 
-With what this DIP proposes, custom types can provide the full range of syntactic possibilities of dynamic indexing,
-with the only difference that the parameters in square brackets be determined compile-time constants
+With what this DIP proposes, custom types can provide the full range of syntactic possibilities of dynamic indexing
+also for the cases when the indexing parameters (the stuff in square brackets) be determined at compile-time
 and made available to the handling members as template parameters instead of function parameters.
 
 As an example, the expression `object[i]` would be rewritten as `object.opStaticIndex!i` first.
-If that succeeds, the handling member `opStaticIndex` can use the value of `i` as a compile-time constant.
+If that succeeds, the handling member `opStaticIndex` can use the value of `i` as a compile-time value.
 If that fails, `object[i]` will be rewritten as `object.opIndex(i)`, where `i` is a function parameter.
 
 As an additional benefit, even if not required, the custom type can check compile-time known indexing parameters
@@ -59,7 +59,7 @@ When a user-defined type has any of the following compiler-recognized members
 * `opDollar`
 
 the compiler generates appropriate rewrites using the aforementioned members
-to provide indexing for that type when using indexing syntax. [1]
+to provide indexing for that type when using indexing syntax.[⁽¹⁾]
 
 These member functions, except `opDollar`, will be called *dynamic indexing operators* in the following,
 in contrast to the *static indexing operators* proposed by this DIP.
@@ -75,7 +75,7 @@ Notably absent is the name `opStaticDollar`.
 The rewrite of `$` remains unchanged,
 as `opDollar` does not require any function parameters.
 
-The DIP proposes that rewriting indexing expressions as per [1],
+The DIP proposes that rewriting indexing expressions as per the spec,[⁽¹⁾]
 the compiler will first try static indexing operators,
 and if that fails, try dynamic indexing operators.
 
@@ -83,7 +83,7 @@ The DIP does not propose to change the rewrites to dynamic indexing operators.
 
 The rewrites to static indexing operators is completely analogous to the dynamic ones,
 with the only difference being that the arguments inside the square brackets will be
-used as template parameters instead of function parameters. 
+used as template parameters instead of function parameters.
 
 * The expression `op object[indices]`, where `op` is some overloadable unary operator,
 is rewritten as `object.opStaticIndexUnary!(op, indices)`.
@@ -91,21 +91,21 @@ is rewritten as `object.opStaticIndexUnary!(op, indices)`.
 is rewritten as `object.opStaticIndexAssign!(indices)(rhs)`.
 If `indices` is the empty sequence and this rewrite fails, the expression
 is rewritten as `object.opStaticIndexAssign(rhs)`,
-i.e. without template instantiation syntax.
+i. e. without template instantiation syntax.
 * The expression `object[indices] op= rhs`, where `op` is some overloadable binary operator,
 is rewritten as `object.opStaticIndexOpAssign!(op, indices)(rhs)`.
 * The expression `object[indices]` if not preceded by a unary operator or preceded by some assignment operator, or
 if so, but the above rewrites failed, will be rewritten as `object.opStaticIndex!(indices)`.
 If `indices` is the empty sequence and this rewrite fails, the expression
 is rewritten as `object.opStaticIndex`,
-i.e. without template instantiation syntax.
+i. e. without template instantiation syntax.
 
 * In any case, if some of the `indices` are of the form `lower .. upper`, that part
 is rewritten as `object.opStaticSlice!(i, lower, upper)`,
 where `i` is the 0-based index of the slice in the square brackets.
 If this rewrite fails, the part
-is rewritten as `object.opStaticSlice!(lower, upper)`, 
-i.e. without the index.
+is rewritten as `object.opStaticSlice!(lower, upper)`,
+i. e. without the index.
 
 If the static rewriting detailed above ultimately fails, rewriting with dynamic indexing operators is done.
 
@@ -113,21 +113,21 @@ If the static rewriting detailed above ultimately fails, rewriting with dynamic 
 
 ### Current State
 
-Currently, the only way to mimic indexing is using alias this to a compile-time sequence (generated e.g. by Phobos' `AliasSeq` template).
-In Phobos, `Tuple` does exactly that.
+Currently, the only way to mimic indexing is using alias this to a compile-time sequence (generated e. g. by Phobos’ `AliasSeq` template[⁽³⁾]).
+In Phobos, `Tuple` does exactly that.[⁽²⁾]
 This has several limitations:
 
 1. While it is possible to have alias this to the sequence and the compiler-recognized member `opIndex` in place,
-the index syntax is not forwarded to the alias this'd sequence anymore
+the index syntax is not forwarded to the alias this’d sequence anymore
 even if the rewrite with `opIndex` fails.
-Phobos' `Tuple` does not overload `opIndex` and therefore does not suffer from this problem.
-2. Even if 1. were resolved, the result of a slice (e.g. `object[l .. u]`) would be a sequence.
-There is no way to hook in and make it evaluate to something different than a sequence, e.g. a user-defined type.
-Consequently, Phobos' `Tuple` when sliced, does not return a `Tuple` but a sequence.
+Phobos’ `Tuple` does not overload `opIndex` and therefore does not suffer from this problem.[⁽²⁾]
+2. Even if 1. were resolved, the result of a slice (e. g. `object[l .. u]`) would be a sequence.
+There is no way to hook in and make it evaluate to something different than a sequence, e. g. a user-defined type.
+Consequently, Phobos’ `Tuple` when sliced, does not return a `Tuple` but a sequence.[⁽²⁾]
 3. The sequence cannot be protected from modifications.
 It is fully exposed without any possibility to manage access to it.
 4. The complete sequence must exist in the first place.
-It might be desirable to pretend the existence of a sequence without storing a sequence (cf. Phobos' `iota`).
+It might be desirable to pretend the existence of a sequence without storing a sequence (cf. Phobos’ `iota`[⁽²⁾]).
 5. As alias this is already taken, one cannot alias this something different.
 
 The whole sequence approach can only be used for indexing with exactly one parameter.
@@ -135,7 +135,7 @@ Multidimensional (including 0-dimensional) indexing is not possible.
 
 Without indexing syntax, it is necessary to use helper function templates, that take
 the indexing parameters as template parameters,
-e.g. like `tuple.index!1` or `tuple.slice!(lBound, uBound)`.
+e. g. like `tuple.index!1` or `tuple.slice!(lBound, uBound)`.
 
 The author believes that using those helper templates is less readable than indexing expressions.
 More objectively, it does not play well in meta-programming contexts,
@@ -148,7 +148,7 @@ The current solution is to ignore tuple-like types or to special-case specific o
 ### Compile-time Function Parameters
 
 If some way to discriminate function parameters for their compile-time availableness were implemented,
-e.g. by a function parameter storage class,
+e. g. by a function parameter storage class,
 the functionality would be implementable using the currently available compiler-recognized members for operator overloading.
 
 The author believes that adding such a storage class is a much greater change of the language as
@@ -162,9 +162,30 @@ This change is purely additional.
 It only affects custom types that have members named like the aforementioned compiler-recognized member names which is presumed unlikely.
 Even then, the change would not actually break that code or change its semantics.
 
-## Reference
+## References
 
-[1] [D Language Specification on Operator Overloading](https://dlang.org/spec/operatoroverloading.html)
+<!--- List of references --->
+
+⁽¹⁾ [D Language Specification on Operator Overloading](https://dlang.org/spec/operatoroverloading.html)
+
+⁽²⁾ [D Library Documentation on std.typecons.Tuple](https://dlang.org/library/std/typecons/tuple.html)
+
+⁽³⁾ [D Library Documentation on std.meta.AliasSeq](https://dlang.org/library/std/meta/alias_seq.html)
+
+⁽⁴⁾ [Alexandrescu at D Language Conference 2017, *Design by Introspection*](https://youtu.be/29h6jGtZD-U)
+
+⁽⁵⁾ [D Language Specification on Implicit Qualifier Conversions](https://dlang.org/spec/const3.html#implicit_qualifier_conversions)
+
+⁽⁶⁾ [D Library Documentation on std.range.iota](https://dlang.org/phobos/std_range.html#.iota)
+
+<!--- Markdown reference definitions --->
+
+[⁽¹⁾]: #references "D Language Specification on Operator Overloading"
+[⁽²⁾]: #references "D Library Documentation on std.typecons.Tuple"
+[⁽³⁾]: #references "D Library Documentation on std.meta.AliasSeq"
+[⁽⁴⁾]: #references "D Language Conference 2017, Talk by Andrei Alexandrescu, Design by Introspection"
+[⁽⁵⁾]: #references "D Language Specification on Implicit Qualifier Conversions"
+[⁽⁶⁾]: #references "D Library Documentation on std.range.iota"
 
 ## Copyright & License
 
@@ -176,3 +197,5 @@ Licensed under [Creative Commons Zero 1.0](https://creativecommons.org/publicdom
 
 The DIP Manager will supplement this section with a summary of each review stage
 of the DIP process beyond the Draft Review.
+
+<!---  ’⁰¹²³⁴⁵⁶⁷⁸⁹⁽⁾ --->

--- a/DIPs/DIP-1NNN-QFS.md
+++ b/DIPs/DIP-1NNN-QFS.md
@@ -123,7 +123,7 @@ is rewritten as `object.opStaticIndexAssign(rhs)`,
 i. e. without template instantiation syntax.
 * The expression `object[indices] op= rhs`, where `op` is an overloadable binary index operator,
 is rewritten as `object.opStaticIndexOpAssign!(op, indices)(rhs)`.
-* The expression `object[indices]` if not preceded by a unary operator or preceded by some assignment operator, or
+* The expression `object[indices]` if not preceded by a unary operator or followed by some assignment operator, or
 if so, but the above rewrites failed, will be rewritten as `object.opStaticIndex!(indices)`.
 If `indices` is the empty sequence and this rewrite fails, the expression
 is rewritten as `object.opStaticIndex`,

--- a/DIPs/DIP-1NNN-QFS.md
+++ b/DIPs/DIP-1NNN-QFS.md
@@ -486,7 +486,7 @@ A concrete corner case is this:
 ```D
 struct Example
 {
-    int opIndex(Ts...)(size_t[] ixs...) { return i; }
+    int opIndex(size_t i = 0)(size_t[] xs...) { return i; }
 }
 ```
 Let `example` be of type `Example` and given the expression `example[1]`,

--- a/DIPs/DIP-1NNN-QFS.md
+++ b/DIPs/DIP-1NNN-QFS.md
@@ -339,13 +339,44 @@ the same way, meta-programming code does not have to distinguish
 dynamic arrays and user-defined random-access ranges when indexing them.
 The current solution is to ignore tuple-like types or to special-case specific ones.
 
-### Alternative Syntax
+### Specific Syntax
 
 If the language maintainers decide that overloading indexing syntax is not desirable,
-the DIP proposes to use the syntax `object![indices]` (note the exclamation mark) for static indexing.
-This syntax is is currently an error and therefore a mere addition to the language.
+the DIP author proposes to use the syntax `object![indices]` (note the exclamation mark) for static indexing.
+This syntax is is currently an error as explicit template instanciation needs parentheses after the exclamation mark
+or a single one-token argument, but anything starting with an opening bracket is not a one-token argument.[⁽⁷⁾]
+Therefore, the proposed syntax a mere addition to the language.
 Accordingly, indexing compile-time sequences should also be possible to do with the syntax `sequence![index]`
 to cater to meta-programming contexts.
+
+In this case, the grammar of the D Programming Language has to be expanded.
+Section 10.22 of the specification[⁽⁸⁾] could be amended as follows:
+```diff
+ SliceExpression:
+     PostfixExpression [ ]
+     PostfixExpression [ Slice ,[opt] ]
++    PostfixExpression ! [ ]
++    PostfixExpression ! [ Slice ,[opt] ]
+ Slice:
+     AssignExpression
+     AssignExpression , Slice
+     AssignExpression .. AssignExpression
+     AssignExpression .. AssignExpression , Slice
+```
+Or, equivalently, it could be changed as follows:
+```diff
+ SliceExpression:
+-    PostfixExpression [ ]
+-    PostfixExpression [ Slice ,[opt] ]
++    PostfixExpression ![opt] [ ]
++    PostfixExpression ![opt] [ Slice ,[opt] ]
+ Slice:
+     AssignExpression
+     AssignExpression , Slice
+     AssignExpression .. AssignExpression
+     AssignExpression .. AssignExpression , Slice
+```
+The author is convinced that amending the grammar is an unnecessary inconveniance which lacks the necessary justifications.
 
 ### Compile-time Function Parameters
 
@@ -380,6 +411,10 @@ Even then, the change would not actually break that code or change its semantics
 
  (6) [D Library Documentation of std.meta.AliasSeq](https://dlang.org/library/std/meta/alias_seq.html)
 
+ (7) [D Language Specification on Explicit Template Instantiation](https://dlang.org/spec/template.html#explicit_tmp_instantiation)
+
+ (8) [D Language Specification on Slice Expressions](https://dlang.org/spec/expression.html#slice_expressions)
+
 <!--- Markdown reference definitions --->
 
 [⁽¹⁾]: #references "D Language Specification on Operator Overloading"
@@ -388,6 +423,8 @@ Even then, the change would not actually break that code or change its semantics
 [⁽⁴⁾]: #references "D Language Conference 2017, Talk by Andrei Alexandrescu, Design by Introspection"
 [⁽⁵⁾]: #references "D Library Documentation on std.range.iota"
 [⁽⁶⁾]: #references "D Library Documentation on std.meta.AliasSeq"
+[⁽⁷⁾]: #references "D Language Specification on Explicit Template Instantiation"
+[⁽⁸⁾]: #references "D Language Specification on Slice Expressions"
 
 ## Copyright & License
 

--- a/DIPs/DIP-1NNN-QFS.md
+++ b/DIPs/DIP-1NNN-QFS.md
@@ -146,15 +146,13 @@ is rewritten as `object.opSlice(lower, upper)`.
 Although not strictly necessary, this DIP proposes to enforce that the template parameters to lowering
 member templates are bound as template value parameters, i. e. to explicitly exclude types or aliases
 as indexing parameters.
-The reason for that are corner cases where types and and expressions
+The reason for that are corner cases where types and expressions
 could be conflated. Consider a user-defined type `T` with the member function declared `static R opIndex();`.
-Then `T[]`, interpreted as a type, *is* the type *slice of `T`*,
-but interpreted as an expression, it rewrites to `T.opIndex()` and *has* the type `R`.
-Therefore in the context `object[ T[] ]`, this rule enforces the rewrite as an expression
-where `T`s member function `opIndex` is called.
+Then `T[]`, interpreted as a type, is the type of slices of `T`,
+but interpreted as an expression, it rewrites to `T.opIndex()` and has the type `R`.
+Therefore in this context, for the expression `object[ T[] ]`, this rule enforces the rewrite to
+`object.opStaticIndex!(T.opIndex())` and does not allow `object.opStaticIndex!(T[])`.
 In the dynamic indexing rewrite, this problem did not arise as it is unambiguous.
-
-This enforcement can be achieved by an identity `enum` template.
 
 It should be mentioned that the language maintainers could decide to only perfer the template value parameter
 rewrite, but allow the binding of indxing parameters to other kinds of template parameter if the rewirites for value parameters fail.

--- a/DIPs/DIP-1NNN-QFS.md
+++ b/DIPs/DIP-1NNN-QFS.md
@@ -123,8 +123,8 @@ is rewritten as `object.opStaticIndexAssign(rhs)`,
 i. e. without template instantiation syntax.
 * The expression `object[indices] op= rhs`, where `op` is an overloadable binary index operator,
 is rewritten as `object.opStaticIndexOpAssign!(op, indices)(rhs)`.
-* The expression `object[indices]` if not preceded by a unary operator or followed by some assignment operator, or
-if so, but the above rewrites failed, will be rewritten as `object.opStaticIndex!(indices)`.
+* The expression `object[indices]`, if not preceded by a unary operator or followed by some assignment operator, or
+if so, when the above rewrites failed, will be rewritten as `object.opStaticIndex!(indices)`.
 If `indices` is the empty sequence and this rewrite fails, the expression
 is rewritten as `object.opStaticIndex`,
 i. e. without template instantiation syntax.

--- a/DIPs/DIP-1NNN-QFS.md
+++ b/DIPs/DIP-1NNN-QFS.md
@@ -1,0 +1,178 @@
+# Compile-time Indexing Operators
+
+| Field           | Value                                                           |
+|-----------------|-----------------------------------------------------------------|
+| DIP:            | (number/id -- assigned by DIP Manager)                          |
+| Review Count:   | 0 (edited by DIP Manager)                                       |
+| Author:         | Quirin F. Schroll <q.schroll@gmail.com>                         |
+| Implementation: | (links to implementation PR if any)                             |
+| Status:         | Will be set by the DIP manager (e.g. "Approved" or "Rejected")  |
+
+## Abstract
+
+In the current state of the D Programming Language, a user-defined type can only
+define indexing operators with function parameters.
+This DIP proposes additional compiler-recognized member names for implementing indexing
+where the indexing parameters are required to be—or handled differently when—known at compile-time.
+
+## Contents
+* [Rationale](#rationale)
+* [Description](#description)
+* [Alternatives](#alternatives)
+* [Breaking Changes and Deprecations](#breaking-changes-and-deprecations)
+* [Reference](#reference)
+* [Copyright & License](#copyright--license)
+* [Reviews](#reviews)
+
+## Rationale
+
+Implementing heterogeneous structures like tuples, indexing syntax can only be implemented in a very narrow way
+(cf. [Alternatives](#alternatives): Current State).
+Given a user-defined tuple type, sophisticated indexing would require handling the indexing parameters as
+compile-time values to determine even the type of the indexing expression.
+
+With the additions proposed by this DIP, it would be possible to make
+e.g. slices of Phobos' `Tuple` return a `Tuple` again.
+
+With what this DIP proposes, custom types can provide the full range of syntactic possibilities of dynamic indexing,
+with the only difference that the parameters in square brackets be determined compile-time constants
+and made available to the handling members as template parameters instead of function parameters.
+
+As an example, the expression `object[i]` would be rewritten as `object.opStaticIndex!i` first.
+If that succeeds, the handling member `opStaticIndex` can use the value of `i` as a compile-time constant.
+If that fails, `object[i]` will be rewritten as `object.opIndex(i)`, where `i` is a function parameter.
+
+As an additional benefit, even if not required, the custom type can check compile-time known indexing parameters
+for validity by overloading both dynamic and static indexing operators.
+This is what the compiler does for static arrays:
+While, formally, indexing is a run-time operation, when using a compile-time known index that is out of bounds,
+the compiler will report an error.
+
+## Description
+
+When a user-defined type has any of the following compiler-recognized members
+* `opIndex`,
+* `opIndexUnary`,
+* `opIndexAssign`,
+* `opIndexOpAssign`,
+* `opSlice`, and
+* `opDollar`
+
+the compiler generates appropriate rewrites using the aforementioned members
+to provide indexing for that type when using indexing syntax. [1]
+
+These member functions, except `opDollar`, will be called *dynamic indexing operators* in the following,
+in contrast to the *static indexing operators* proposed by this DIP.
+
+The DIP proposes to add the following names to the compiler-recognized member names for operator overloading:
+* `opStaticIndex`
+* `opStaticIndexUnary`
+* `opStaticIndexAssign`
+* `opStaticIndexOpAssign`
+* `opStaticSlice`
+
+Notably absent is the name `opStaticDollar`.
+The rewrite of `$` remains unchanged,
+as `opDollar` does not require any function parameters.
+
+The DIP proposes that rewriting indexing expressions as per [1],
+the compiler will first try static indexing operators,
+and if that fails, try dynamic indexing operators.
+
+The DIP does not propose to change the rewrites to dynamic indexing operators.
+
+The rewrites to static indexing operators is completely analogous to the dynamic ones,
+with the only difference being that the arguments inside the square brackets will be
+used as template parameters instead of function parameters. 
+
+* The expression `op object[indices]`, where `op` is some overloadable unary operator,
+is rewritten as `object.opStaticIndexUnary!(op, indices)`.
+* The expression `object[indices] = rhs`
+is rewritten as `object.opStaticIndexAssign!(indices)(rhs)`.
+If `indices` is the empty sequence and this rewrite fails, the expression
+is rewritten as `object.opStaticIndexAssign(rhs)`,
+i.e. without template instantiation syntax.
+* The expression `object[indices] op= rhs`, where `op` is some overloadable binary operator,
+is rewritten as `object.opStaticIndexOpAssign!(op, indices)(rhs)`.
+* The expression `object[indices]` if not preceded by a unary operator or preceded by some assignment operator, or
+if so, but the above rewrites failed, will be rewritten as `object.opStaticIndex!(indices)`.
+If `indices` is the empty sequence and this rewrite fails, the expression
+is rewritten as `object.opStaticIndex`,
+i.e. without template instantiation syntax.
+
+* In any case, if some of the `indices` are of the form `lower .. upper`, that part
+is rewritten as `object.opStaticSlice!(i, lower, upper)`,
+where `i` is the 0-based index of the slice in the square brackets.
+If this rewrite fails, the part
+is rewritten as `object.opStaticSlice!(lower, upper)`, 
+i.e. without the index.
+
+If the static rewriting detailed above ultimately fails, rewriting with dynamic indexing operators is done.
+
+## Alternatives
+
+### Current State
+
+Currently, the only way to mimic indexing is using alias this to a compile-time sequence (generated e.g. by Phobos' `AliasSeq` template).
+In Phobos, `Tuple` does exactly that.
+This has several limitations:
+
+1. While it is possible to have alias this to the sequence and the compiler-recognized member `opIndex` in place,
+the index syntax is not forwarded to the alias this'd sequence anymore
+even if the rewrite with `opIndex` fails.
+Phobos' `Tuple` does not overload `opIndex` and therefore does not suffer from this problem.
+2. Even if 1. were resolved, the result of a slice (e.g. `object[l .. u]`) would be a sequence.
+There is no way to hook in and make it evaluate to something different than a sequence, e.g. a user-defined type.
+Consequently, Phobos' `Tuple` when sliced, does not return a `Tuple` but a sequence.
+3. The sequence cannot be protected from modifications.
+It is fully exposed without any possibility to manage access to it.
+4. The complete sequence must exist in the first place.
+It might be desirable to pretend the existence of a sequence without storing a sequence (cf. Phobos' `iota`).
+5. As alias this is already taken, one cannot alias this something different.
+
+The whole sequence approach can only be used for indexing with exactly one parameter.
+Multidimensional (including 0-dimensional) indexing is not possible.
+
+Without indexing syntax, it is necessary to use helper function templates, that take
+the indexing parameters as template parameters,
+e.g. like `tuple.index!1` or `tuple.slice!(lBound, uBound)`.
+
+The author believes that using those helper templates is less readable than indexing expressions.
+More objectively, it does not play well in meta-programming contexts,
+where one would like to not have to distinguish the cases of user-defined types,
+static arrays and compile-time sequences
+the same way, meta-programming code does not have to distinguish
+dynamic arrays and user-defined random-access ranges when indexing them.
+The current solution is to ignore tuple-like types or to special-case specific ones.
+
+### Compile-time Function Parameters
+
+If some way to discriminate function parameters for their compile-time availableness were implemented,
+e.g. by a function parameter storage class,
+the functionality would be implementable using the currently available compiler-recognized members for operator overloading.
+
+The author believes that adding such a storage class is a much greater change of the language as
+it affects the mechanics of function overloading and makes reasoning about code more difficult.
+Detailing out, what that change would exactly entail, is beyond the scope of this DIP.
+The author only mentions this alternative as this might encourage that evaluation by someone else.
+
+## Breaking Changes and Deprecations
+
+This change is purely additional.
+It only affects custom types that have members named like the aforementioned compiler-recognized member names which is presumed unlikely.
+Even then, the change would not actually break that code or change its semantics.
+
+## Reference
+
+[1] [D Language Specification on Operator Overloading](https://dlang.org/spec/operatoroverloading.html)
+
+## Copyright & License
+
+Copyright (c) 2018 by the D Language Foundation
+
+Licensed under [Creative Commons Zero 1.0](https://creativecommons.org/publicdomain/zero/1.0/legalcode.txt)
+
+## Reviews
+
+The DIP Manager will supplement this section with a summary of each review stage
+of the DIP process beyond the Draft Review.

--- a/DIPs/DIP-1NNN-QFS.md
+++ b/DIPs/DIP-1NNN-QFS.md
@@ -6,7 +6,7 @@
 | Review Count:   | 0 (edited by DIP Manager)                                       |
 | Author:         | Quirin F. Schroll (q.schroll@gmail.com)                         |
 | Implementation: | *none*                                                          |
-| Status:         | *Will be set by the DIP manager*                                |
+| Status:         | Draft                                                           |
 
 ## Abstract
 

--- a/DIPs/DIP-1NNN-QFS.md
+++ b/DIPs/DIP-1NNN-QFS.md
@@ -2,11 +2,11 @@
 
 | Field           | Value                                                           |
 |-----------------|-----------------------------------------------------------------|
-| DIP:            | (number/id -- assigned by DIP Manager)                          |
+| DIP:            | *TBD by DIP Manager*                                            |
 | Review Count:   | 0 (edited by DIP Manager)                                       |
 | Author:         | Quirin F. Schroll (q.schroll@gmail.com)                         |
-| Implementation: | (links to implementation PR if any)                             |
-| Status:         | Will be set by the DIP manager (e. g. "Approved" or "Rejected") |
+| Implementation: | *none*                                                          |
+| Status:         | *Will be set by the DIP manager*                                |
 
 ## Abstract
 
@@ -27,7 +27,7 @@ where the indexing parameters are required to be – or handled differently when
 ## Rationale
 
 Implementing heterogeneous structures like tuples, indexing syntax can only be implemented in a very narrow way
-(cf. [Current State Alternatives](#current-state).
+(cf. [Current State Alternatives](#current-state)).
 Given a user-defined tuple type, sophisticated indexing would require handling the indexing parameters as
 compile-time values to determine even the type of the indexing expression.
 
@@ -240,7 +240,7 @@ template iota(T, T start, T end, T step)
     }
 }
 
-alias i = iota!(int, 1, 10+1, 2);
+alias i = iota!(int, 1, 10 + 1, 2);
 
 static assert(i[0] == 1); // rewrites to static assert(i.opStaticIndex!0 == 1);
 static assert(i[1] == 3); // rewrites to static assert(i.opStaticIndex!1 == 3);
@@ -248,9 +248,9 @@ static assert(i[1] == 3); // rewrites to static assert(i.opStaticIndex!1 == 3);
 
 It could be argued that this semantics can be implemented easily in the current form of the language
 and that the proposed static indexing syntax is mere a readability concern,
-but syntax is relevant in a metaprogramming context.
+but syntax is relevant in a meta-programming context.
 
-### Simulate Compile-time Aware Funcion Parameters
+### Simulate Compile-time Aware Function Parameters
 
 Utilizing `static` members, a type can be defined that
 


### PR DESCRIPTION
This DIP proposes additional compiler-recognized member names for implementing indexing
where the indexing parameters are required to be—or handled differently when—known at compile-time.

For example, the expression `object[i]` would be rewritten as `object.opStaticIndex!i` first. If that succeeds, the handling member template `opStaticIndex` can use the value of `i` as a compile-time constant. If it fails, `object[i]` will be rewritten as `object.opIndex(i)`, where `i` is a regular function parameter.