### PR TITLE
[1022] Breaking changes and deprecations, and walked through Mike's corrections

### DIFF
--- a/DIPs/DIP1022.md
+++ b/DIPs/DIP1022.md
@@ -157,24 +157,21 @@ import containers;
 auto dynamicArray(R)(R range)
 {
     auto result = DynamicArray!(ElementType!R).init;
-    foreach (el; range)
-        result.put(el);
+    foreach (el; range) result.put(el);
     return result;
 }
 
 void writeDeepLengthA(Roi)(Roi rangeOfIterables)
 {
     typeof(rangeOfIterables.front.front) sum;
-    foreach (iterable; rangeOfIterables)
-        sum += iterable.length;
+    foreach (iterable; rangeOfIterables) sum += iterable.length;
     sum.writeln;
 }
 
 void writeDeepLengthB(Roi)(Roi rangeOfIterables)
 {
     typeof(rangeOfIterables.front.front) sum;
-    foreach (ref iterable; rangeOfIterables)
-        sum += iterable.length;
+    foreach (ref iterable; rangeOfIterables) sum += iterable.length;
     sum.writeln;
 }
 
@@ -182,8 +179,7 @@ void writeDeepLengthB(Roi)(Roi rangeOfIterables)
 void writeDeepLengthC(Roi)(Roi rangeOfIterables)
 {
     typeof(rangeOfIterables.front.front) sum;
-    foreach(auto ref iterable; rangeOfIterables)
-        sum += iterable.length;
+    foreach(auto ref iterable; rangeOfIterables) sum += iterable.length;
     sum.writeln;
 }
 
@@ -194,7 +190,8 @@ void main()
 
     // Vice-versa
     auto uniqueElements =
-    [   only(7, 2, 29, 30).dynamicArray,
+    [   
+		only(7, 2, 29, 30).dynamicArray,
         only(11, 9, 0).dynamicArray,
         takeNone!(int[]).dynamicArray,
         only(3, 30, 14, 19, 4, 0, 9).dynamicArray
@@ -274,7 +271,14 @@ void main()
 
 - <a name="aliasseq"></a>specification of iteration over alias sequences:
 	* https://dlang.org/spec/statement.html#foreach_over_tuples
+	
+## Breaking Changes And Deprecations
 
+This DIP will deprecate an unknown amount of code. Every use of `foreach(ref <...>)`
+where elements of aggregate are rvalues[2] will be deprecated. The migration
+will be to change such loops to either `foreach(<...>)` of `foreach(auto ref <...>)`.
+
+No code will break without a deprecation phase.
 
 ## Copyright & License
 

--- a/DIPs/DIP1022.md
+++ b/DIPs/DIP1022.md
@@ -112,7 +112,7 @@ If the compiler encounters a `foreach` statement such as this:
 ```D
 foreach (auto ref loopVariable3; anAliasSequence)
 {
-	loopVariable3.doSomething();
+    loopVariable3.doSomething();
 }
 ```
 
@@ -125,8 +125,8 @@ where `loopVariable3` aliases to an rvalue must be compiled as if written like t
 ```D
 foreach (__HIDDEN_ALIAS; anAliasSequence)
 {
-	auto loopVariable3 = __HIDDEN_ALIAS;
-	loopVariable3.doSomething();
+    auto loopVariable3 = __HIDDEN_ALIAS;
+    loopVariable3.doSomething();
 }
 ```
 
@@ -191,7 +191,7 @@ void main()
     // Vice-versa
     auto uniqueElements =
     [   
-		only(7, 2, 29, 30).dynamicArray,
+        only(7, 2, 29, 30).dynamicArray,
         only(11, 9, 0).dynamicArray,
         takeNone!(int[]).dynamicArray,
         only(3, 30, 14, 19, 4, 0, 9).dynamicArray
@@ -221,14 +221,14 @@ void main()
 ## Alternatives
 
 - `ref` could retain the current behavior and a different syntax could be used
-	to do what `ref` should do according to this proposal. The advantage is that no
-	deprecation period is required. The disadvantage is that the semantics of `ref`
-	will remain inconsistent between function signatures and `foreach` loops.
+    to do what `ref` should do according to this proposal. The advantage is that no
+    deprecation period is required. The disadvantage is that the semantics of `ref`
+    will remain inconsistent between function signatures and `foreach` loops.
 
 - While deprecating `ref` as described by this paper, instead of implementing
-	`foreach(auto ref ...)` a library solution could be implemented that takes an
-	`alias` compile-time parameter and chooses the iteration method on behalf of the programmer.
-	`std.algorithm.iteration.each` [[7](#algo)] would be a good candidate. This
+    `foreach(auto ref ...)` a library solution could be implemented that takes an
+    `alias` compile-time parameter and chooses the iteration method on behalf of the programmer.
+    `std.algorithm.iteration.each` [[7](#algo)] would be a good candidate. This
     concept has the following disadvantages:
     - Error messages become harder to read than with normal loops,
     - Using `goto`, labeled `break` and `continue`, and `return` inside the loop
@@ -264,14 +264,14 @@ void main()
     * https://github.com/dlang-community/containers
 
 - <a name="autoref"></a>`auto ref` language specification for function return values:
-	* https://dlang.org/spec/function.html#auto-ref-functions
+    * https://dlang.org/spec/function.html#auto-ref-functions
 
 - <a name="algo"></a>std.algorithm.iteration.each documentation
     * https://dlang.org/phobos/std_algorithm_iteration.html#.each
 
 - <a name="aliasseq"></a>specification of iteration over alias sequences:
-	* https://dlang.org/spec/statement.html#foreach_over_tuples
-	
+    * https://dlang.org/spec/statement.html#foreach_over_tuples
+    
 ## Breaking Changes And Deprecations
 
 This DIP will deprecate an unknown amount of code. Every use of `foreach(ref <...>)`


### PR DESCRIPTION
I decided to keep single-line bodies of `foreach` at the same line. No general style guide forbids
that AFAIK, but I did not revert to Horstmann brace style, as I know I'm on minority there.

If this is okay for Mike, you can pass it to community phase right away.