### PR TITLE
Update 1023 DIP after round 1

### DIFF
--- a/DIPs/DIP1023.md
+++ b/DIPs/DIP1023.md
@@ -21,35 +21,35 @@
 
 D has type aliases that can be templates:
 ```d
-struct TemplateType(T) { }
-alias TemplateAlias(T) = TemplateType!T
+struct TypeTemplate(T) { }
+alias AliasTemplate(T) = TypeTemplate!T
 ```
 
-D also has template functions for which the template parameters are resolved when the template is instantiatied:
+D also has function templates for which the template parameters are resolved when the template is instantiated:
 ```d
-struct TemplateType(T) { }
-void templateFunction(TemplateType!T arg) { }
-TemplateType!int inst;
-templateFunction(inst); /* template instantiated with T = int */
+struct TypeTemplate(T) { }
+void functionTemplate(T)(TypeTemplate!T arg) { }
+TypeTemplate!int inst;
+functionTemplate(inst); /* template instantiated with T implicitly being resolved to `int` */
 ```
 
-Combining template aliases and template functions, it should be possible to have template aliases
-as formal parameter types of template functions:
+Combining alias templates and function templates, it should be possible to have alias templates
+as formal parameter types of function templates:
 ```d
-struct TemplateType(T) { }
-alias TemplateAlias(T) = TemplateType!T
-void templateFunction(TemplateAlias!T arg) { }
+struct TypeTemplate(T) { }
+alias AliasTemplate(T) = TypeTemplate!T;
+void functionTemplate(T)(AliasTemplate!T arg) { }
 ```
 
-However, the compiler produces an error when a template alias is used as a formal function parameter.
+However, the compiler produces an error when an alias template is used as a formal function parameter.
 This is not a bug because the desired behaviour is not specified. As such, [existing reports of the issue](#reference) are tagged as 'Enhancements'.
 
-This DIP proposes a specification for template aliases as formal function parameters.
+This DIP proposes a specification for alias templates as formal function parameters.
 
 ## Rationale
 
 It is quite common for a series of (one or more) nested template instantiations to be considered as one semantic entity, especially for data science libraries.
-Consider the following D template function:
+Consider the following D function template:
 ```d
 auto foo(T)(Slice!(StairsIterator!(T*, "-")) m)
 {
@@ -64,7 +64,7 @@ alias PackedUpperTriangularMatrix(T) = Slice!(StairsIterator!(T*, "-"));
 auto foo(T)(PackedUpperTriangularMatrix!T m) { }
 ```
 
-Packing the RHS instances in an alias is not only a way to reduce code size but, most importantly,
+Packing the right-hand-side instances in an alias is not only a way to reduce code size but, most importantly,
 it removes the burden from the user to know what a `PackedUpperTriangularMatrix` actually is. Right now,
 the user is exposed to unnecessary details, leading to code that is not as easy to comprehend.
 
@@ -75,51 +75,50 @@ auto foo(T)(T m) if(isPackedUpperTriangularMatrix!T) { /* ... */ }
 ```
 
 The thesis is that in real-world situations, this alternative produces quite more unreadable code.
-It is has been discussed more extensively on [the comments of the pull request](https://github.com/dlang/dmd/pull/9778#issuecomment-496169602)
+It is has been discussed more extensively on [the comments of the pull request](https://github.com/dlang/dmd/pull/9778#issuecomment-496169602).
 
 ## Description
-**Current behavior**: A template alias function parameter is not resolved to its aliased instance until after the function
-resolution stage. So with the following code:
+**Current behavior**: An alias template used as a function parameter is not resolved to its aliased instance until after the function resolution stage. So with the following code:
 ```d
-struct TemplateType(T) {}
-template aliasAlias(T) = TemplateType!T;
-void templateFunction(T)(TemplateAlias!T arg) {}
+struct TypeTemplate(T) {}
+alias AliasTemplate(T) = TypeTemplate!T;
+void functionTemplate(T)(AliasTemplate!T arg) {}
 
 void main()
 {
-    TemplateAlias!int inst;
-    templateFunction(inst); /* "cannot deduce function from argument types !()(TemplateType!int)" */
+    AliasTemplate!int inst;
+    functionTemplate(inst); /* "cannot deduce function from argument types !()(TypeTemplate!int)" */
 }
 ```
 We get the following error message:
 ```d
-template templateFunction cannot deduce function from argument types !()(TemplateType!int), candidates are:
-templateFunction(T)(TemplateAlias!T arg)
+template functionTemplate cannot deduce function from argument types !()(TypeTemplate!int), candidates are:
+functionTemplate(T)(AliasTemplate!T arg)
 ```
-The compiler sees `TemplateAlias` and `TemplateType` as two different types, so it can't match `TemplateType!int` against
-`TemplateAlias!T`. Although the compiler has resolved the type of `inst` to `TemplateType!int`, it has not resolved the
-formal parameter type to be `TemplateType!T`.
+The compiler sees `AliasTemplate` and `TypeTemplate` as two different types, so it can't match `TypeTemplate!int` against `AliasTemplate!T`.
+Although the compiler has resolved the type of `inst` to `TypeTemplate!int`, it has not resolved the
+formal parameter type to be `TypeTemplate!T`.
 
-**New behavior**: Full handling of the feature is complicated because a template (alias) has arbitrary pattern matching and rewrite abilities over types. For instance, a template alias:
- * can accept type parameters that it never uses (e.g., `alias TemplateAlias(T) = int;`)
- * can accept a type parameter and use it multiple times (e.g., `alias TemplateAlias(T) = TemplateType!(T,T);`)
- * can infer a type parameter when given a complex type expression (e.g., `alias TemplateAlias(A: A*, B) = TemplateType!(A, B);`).
+**New behavior**: Full handling of the feature is complicated because a (alias) template has arbitrary pattern matching and rewrite abilities over types. For instance, an alias template:
+ * can accept type parameters that it never uses (e.g., `alias AliasTemplate(T) = int;`)
+ * can accept a type parameter and use it multiple times (e.g., `alias AliasTemplate(T) = TypeTemplate!(T,T);`)
+ * can infer a type parameter when given a complex type expression (e.g., `alias AliasTemplate(A: A*, B) = TypeTemplate!(A, B);`).
 
-Therefore, the crux of the proposal is to encode this pattern matching and type rewriting into a function, `Gen`, and invoke it at the right time during compilation. It is not to define that pattern-matching or the type-rewriting.
+The purpose of this DIP is not to formally define the pattern-matching and the type-rewriting. Instead, an abstract function, `Gen`, is assumed that provides these capabilities. And the rest of this proposal is concerned with how to formally describe the resolution of formal arguments in function templates that are alias templates.
 
-Specifically, if the type of the formal parameter of a template function is an instance of a template alias declaration, instantiate the type that the declaration aliases; that becomes the new type of the parameter. This is done by calling the function below in each parameter. This should be done before function calls are resolved.
+Specifically, if the type of the formal parameter of a function template is an instance of an alias template declaration, instantiate the type that the declaration aliases; that becomes the new type of the parameter. This is done by calling the function below in each parameter. This should be done before function calls are resolved.
 In pseudocode:
 ```d
 resolveAlias(ref parameterType) {
     while (parameterType is templateInstance) {
         for (arg in parameterType.paramMap.values) {
-            if (arg is templateInstance && arg.TD is templateAliasDeclaration) {
+            if (arg is templateInstance && arg.TD is aliasTemplateDeclaration) {
                 // Recursively resolve nested aliases
                 resolveAlias(arg);
             }
         }
         // Assume that parameterType was generated using `Gen`
-        if (parameterType.TD is templateAliasDeclaration) {
+        if (parameterType.TD is aliasTemplateDeclaration) {
             aliasedType = TD.aliasedType;
             if (aliasedType is templateInstance) {
                 newTD = aliasedType.TD;
@@ -134,13 +133,12 @@ resolveAlias(ref parameterType) {
     }
 }
 ```
-For the following discussion, the recursive nature of the procedure (i.e., the nexted `for`) is ignored.
+For the following discussion, the recursive nature of the procedure (i.e., the nested `for`) is ignored.
 
 `Gen` is a function that takes 2 arguments, `TD` and the list `T1, ..., Tn`.
 `TD` is a template declaration.
 `T1, ..., T2` are arguments (actual parameters) provided to a template declaration.
-The expression `Gen(TD, (T1, ..., Tn)` generates an instance of the declaration `TD` when `T1, ..., Tn` are provided
-as arguments. The generated instance also fills:
+The expression `Gen(TD, (T1, ..., Tn)` generates an instance of the declaration `TD` when `T1, ..., Tn` are provided as arguments. The generated instance also fills:
 * `.paramMap`, which maps each formal parameter to the corresponding argument.
 * `.TD`, which is the template declaration used.
 
@@ -150,8 +148,7 @@ A template argument can be:
 2) A type declarator using a template declaration formal parameter like `T`, `T*`, etc.
 3) A type declarator using both known types and formal parameters, like `T[int]`.
 
-For 2. to be true, the instantiation should happen inside a template declaration. In this case, the formal parameters
-that are used by any argument must be a subset of the formal parameters of the declaration.
+For 2. to be true, the instantiation should happen inside a template declaration. In this case, the formal parameters that are used by any argument must be a subset of the formal parameters of the declaration.
 
 **Additional notes**:
 - The number of arguments must be the same with the number of formal parameters of the template declaration.
@@ -159,83 +156,80 @@ that are used by any argument must be a subset of the formal parameters of the d
 - The generation should take into consideration the pattern-matching capabilities of the language in template parameters.
 Examples:
 ```
-Gen(struct TemplateType(T) { }, (int*)) -> TemplateType!(int*)
-Gen(struct TemplateType(T) { }, (T[int])) -> TemplateType!(T[int])
-Gen(alias TemplateAlias(T) = TemplateType!T, (int*)) -> TemplateAlias!(int*)
-Gen(alias TemplateAlias(T, Q) = TestType!T, (int*)) -> TemplateAlias!(int*)
+Gen(struct TypeTemplate(T) { }, (int*)) -> TypeTemplate!(int*)
+Gen(struct TypeTemplate(T) { }, (T[int])) -> TypeTemplate!(T[int])
+Gen(alias AliasTemplate(T) = TypeTemplate!T, (int*)) -> AliasTemplate!(int*)
+Gen(alias AliasTemplate(T, Q) = TestType!T, (int*)) -> AliasTemplate!(int*)
 ```
 
 We assume that all instances have been generated using `Gen`.
 
-If `TD` is a template alias declaration, then `TD.aliasedType` is the type that `TD` aliases.
+If `TD` is an alias template declaration, then `TD.aliasedType` is the type that `TD` aliases.
 Example:
 ```d
-struct TemplateType(T) { }
-alias TemplateAlias(T) = TemplateType!T
+struct TypeTemplate(T) { }
+alias AliasTemplate(T) = TypeTemplate!T
 ```
-`.aliasedType` of `alias TemplateAlias(T)` is `TemplateType!T`.
+`.aliasedType` of `alias AliasTemplate(T)` is `TypeTemplate!T`.
 If that type is an instantiation of a template declaration, we find that declaration using `findTempDecl()`.
 
-Notice that if `aliasedType` isn't a template instance, we stop. This is important, because there are other reasons that
-we want to stop that have to do with the implementation. (More on that in [the article referenced below](#reference).)
+Notice that if `aliasedType` isn't a template instance, we stop. This is important, because there are other reasons that we want to stop that have to do with the implementation. (More on that in [the article referenced below](#reference).)
 
-`matchParams()` is a function that takes 2 arguments: one argument list (call it `al`) and one parameter map (call
-it `m`, a map of formal parameters to arguments / type declarators). `al` is of course a list of template arguments.
+`matchParams()` is a function that takes 2 arguments: one argument list (call it `al`) and one parameter map (call it `m`, a map of formal parameters to arguments / type declarators).
+`al` is of course a list of template arguments.
 It generates a new argument list so any formal parameter used in some argument in `al` is replaced
 with the argument that it maps to (using the `m`).
 
 A sample loop execution:
 ```d
 // Declarations
-struct TemplateType(W) { }
-alias TemplateAlias(Q, S) = TemplateType!Q;
+struct TypeTemplate(W) { }
+alias AliasTemplate(Q, S) = TypeTemplate!Q;
 
-parameterType := TemplateAlias!(int*, float)
-// Gen looks like this: Gen(alias TemplateAlias(Q, S) = TemplateType!Q, (int*, float)) -> TemplateAlias!(int*, float)
-TD := alias TemplateAlias(Q, S) = TemplateType!Q
+parameterType := AliasTemplate!(int*, float)
+// Gen looks like this: Gen(alias AliasTemplate(Q, S) = TypeTemplate!Q, (int*, float)) -> AliasTemplate!(int*, float)
+TD := alias AliasTemplate(Q, S) = TypeTemplate!Q
 (T1, ..., Tn) := (int*, float)  (where T1 := int* and T2 := float)
-parameterType := TemplateAlias!(int*, float)
+parameterType := AliasTemplate!(int*, float)
 parameterType.paramMap := { Q: int*, S: float }
-TD.aliasedType := TemplateType!Q
-newTD := struct TemplateType(W) { }
+TD.aliasedType := TypeTemplate!Q
+newTD := struct TypeTemplate(W) { }
 aliasedType.paramList := (Q)
 newArgumentList = (int*)  // 'Q' was replaced by int* using the map
-parameterType = TemplateType!(int*)
+parameterType = TypeTemplate!(int*)
 ```
 
 The last thing to be explained is the `for` at the start of the function. Consider the following example:
 ```d
-struct TemplateType1(T) { }
-struct TemplateType2(Q) { }
-alias TemplateAlias1(S) = TemplateType2!S
-alias TemplateAlias2(V) = TemplateType1!(TemplateAlias1!V)
+struct TypeTemplate1(T) { }
+struct TypeTemplate2(Q) { }
+alias AliasTemplate1(S) = TypeTemplate2!S
+alias AliasTemplate2(V) = TypeTemplate1!(AliasTemplate1!V)
 ```
 It is clear that the procedure of resolving an alias instance has a recursive nature. That is because
-aliases can instantiate other aliases. So thr `for`, for each argument on the map of arguments that the `parameterType` instance
-received, first resolves any nested aliases.
+aliases can instantiate other aliases. So the `for`, for each argument on the map of arguments that the `parameterType` instance received, first resolves any nested aliases.
 
 ### Caveats
 #### Changing the parameter type might not be enough
 Consider this example:
 ```d
-struct TemplateType(W) {}
-alias TemplateAlias(S, V) = TemplateType!(S);
-void templateFunction(T, Q)(TemplateAlias!(T, Q) arg) {}
+struct TypeTemplate(W) {}
+alias AliasTemplate(S, V) = TypeTemplate!(S);
+void functionTemplate(T, Q)(AliasTemplate!(T, Q) arg) {}
 ```
 Using the above logic, the parameter resolves to this:
 ```d
-void templateFunction(T, Q)(TemplateType!T arg) {}
+void functionTemplate(T, Q)(TypeTemplate!T arg) {}
 ```
 Notice that this does not compile. The reason is that `Q` is never used. It was _dropped_ in the process
 of resolving the alias. For the specification to be complete, we need to consider that, if in the resolution
-process a formal parameter of the function is dropped, then the type of the function has to change in more ways than
-the function parameters. Its template parameters should also be reduced.
+process a formal parameter of the function is dropped, then the type of the function has to change in more ways than the function parameters. The number of its template parameters should also be reduced.
 
 #### Cyclic aliases
 Templates in D are Turing-complete. Because of this, deciding a-priori if a template instantiation will ever
-finish retreats to the [halting problem](https://en.wikipedia.org/wiki/Halting_problem). For this reason,
-the DIP proposes the implementation for alias resolution detect cycles on the _declaration_ level.
-That is, if an attempt is made to instantiate the same declaration again during an alias resolution, stop.
+finish retreats to the [halting problem](https://en.wikipedia.org/wiki/Halting_problem).
+For this reason, the DIP proposes the implementation for alias resolution detect cycles
+on the _declaration_ level. That is, if an attempt is made to instantiate the same declaration again during an alias resolution, stop.
 
 ## Breaking Changes and Deprecations
 There are no breaking changes or deprecations and no problem with backwards compatibility. This is a pure


### PR DESCRIPTION
Changes Summary:
1) Change terminology to match the D documentation ('alias template', 'function template' etc.)
2) Typos
3) Clarify that Gen is an abstract function and that it's part of this formal description. It is not linked with the (compiler) implementation.