### PR TITLE
DIP1024: address Community Review Round 1 criticisms

### DIFF
--- a/DIPs/DIP1024.md
+++ b/DIPs/DIP1024.md
@@ -10,8 +10,9 @@
 
 ## Abstract
 
-Reads and writes to data typed as `shared` are made atomic where the target CPU supports
-atomic operations and become erroneous when they cannot be done atomically.
+Reads and writes to data typed as `shared` are not supported by operators
+in the core language. They are only accessible via function calls from
+the library.
 
 
 ## Contents
@@ -26,12 +27,13 @@ atomic operations and become erroneous when they cannot be done atomically.
 
 Making shared types a first class type in D was an effective innovation. The ability
 to distinguish the shared and unshared data is critical for developing robust multi-threaded
-applications. But D stops short of altering the semantics of access to shared data,
+applications. But D stopped short of altering the semantics of access to shared data,
 making the default behavior subject to data races both obvious and hidden as the result of code
 motion by optimizing compilers.
 
 By prohibiting direct access to shared data, the user will be required to use `core.atomic`
 and to consider the correctness of their code.
+
 
 ### Using core.atomic instead
 
@@ -45,77 +47,21 @@ This proposal does not guarantee code will be deadlock-free, nor does it obviate
 for locks for transaction-race-free behavior. (A transaction is a sequence of operations
 that must occur without another thread altering the shared data before the transaction is completed.)
 
+It does not prohibit casting shared data to unshared data, and then operating on it via
+the core language operators, although such would only be allowed in `@system` and `@trusted`
+code.
+
+
 ## Description
 
 Atomic reads perform an acquire operation, writes perform a release operation, and read-modify-write
 performs an acquire, then a modification, and then a release. The result is sequentially consistent ordering,
 and each thread observes the same order of operations (total order).
 
-The code generated would be equivalent to that from the `core.atomic` library for the supported operations.
+The core language itself will not do these operations, but instead will rely on functions to do
+it. These can be ones from the `core.atomic` library, or functions the user writes.
 
 There are no syntactical changes.
-
-The supported operations are implementation defined for the target processor.
-Supported operations are expected to be efficiently supported by the target
-processor.
-
-Inefficient operations must be programmed by the user with locks and will thereby stand out in
-source code, preventing hidden performance surprises.
-
-Whether a specific atomic operation is supported can be tested at compile time using
-`__traits(compiles,...)`.
-
-
-### Optimizations
-
-Much like the C `volatile` type, many optimizations are not performed on atomic operations.
-Such optimizations are any that would:
-
-* cache the value of an atomic operation
-* allocate an atomic variable in a register
-* re-order atomic operations
-
-Some examples are Common Subexpression Elimination, Copy Propagation, Loop Invariant
-Removal, Dead Store Elimination, etc.
-
-There are more code motion restrictions:
-
-```d
-__gshared int g=0;
-shared int x=0;
-
-void thread1(){
-    g=1; // non-atomic store
-    x=1; // atomic store, release, happens after everything above
-}
-
-void thread2(){
-    if(x==1){ // atomic load, acquire, happens before everything below
-        assert(g==1); // non-atomic load
-    }
-}
-```
-
-I.e. code motion of `__gshared` cannot move across atomic operations. Surprisingly,
-this applies to locals as well, even though locals are not supposed to be visible
-to other threads. This is because:
-
-1. the address of a `__gshared` variable is taken; the type system does not distinguish
-between that and the address of a local variable, so the optimizer must assume it is
-`__gshared`.
-
-2. the implementor of lock-free algorithms may wish to temporarily cast a shared variable
-to unshared to get the expected non-atomic, but synchronized, behavior seen in the example above.
-This would break if the compiler moved locals across atomic operations, and so such code
-motion cannot be done.
-
-
-### Risks
-
-Will it work? Since it's just replacing calls to `core.atomic` with language support, and atomics
-are well understood (at least by experts) in multiple languages, there should be little risk.
-This is not pioneering new ground. The only innovation is support by the language
-type system rather than library calls.
 
 
 ### Alternatives


### PR DESCRIPTION
Made it clear that read/write to shared types can only be done via function calls.