### PR TITLE
@nodiscard

### DIFF
--- a/DIPs/1NNN-PJB.md
+++ b/DIPs/1NNN-PJB.md
@@ -6,7 +6,7 @@
 | Review Count:   | 0 (edited by DIP Manager)                                       |
 | Author:         | Paul Backus (snarwin@gmail.com)                                 |
 | Implementation: | <https://github.com/dlang/dmd/pull/11765>                       |
-| Status:         | Will be set by the DIP manager (e.g. "Approved" or "Rejected")  |
+| Status:         | Draft                                                           |
 
 ## Abstract
 

--- a/DIPs/1NNN-PJB.md
+++ b/DIPs/1NNN-PJB.md
@@ -81,14 +81,14 @@ Unfortunately, using `out` parameters for error handling is not a
 general-purpose solution, because the programmer is not always free to change a
 function's signature to include an `out` parameter. Reasons for this include:
 
-* The function is part of an external library written in another language.
-* The function is an override of a virtual function that is part of an
-  established public API.
-* The function is used as an argument to a higher-order function such as `map`
-  or `filter` that requires a particular signature.
+* The function's signature is part of an established public API, and changing
+  it would break other code.
+* The function is used as a callback by another function that requires it to
+  have a specific signature.
+* The function is an operator overload.
 
-By contrast, `@nodiscard` can be used with any kind of function, because all
-functions have a return type.
+By contrast, `@nodiscard` can be used with any function, because all functions
+have a return type.
 
 [Dub]: https://code.dlang.org/
 

--- a/DIPs/1NNN-PJB.md
+++ b/DIPs/1NNN-PJB.md
@@ -57,7 +57,8 @@ forums; see the [Reference](#reference) section below for details.
 An expression is considered to be discarded if and only if:
 
 * It is the top-level *Expression* in an *ExpressionStatement*.
-* It is the *AssignExpression* on the left-hand side of a *CommaExpression*.
+* It is the *AssignExpression* on the left-hand side of the comma in a
+  *CommaExpression*.
 
 It is a compile-time error to discard the value of an expression if:
 
@@ -66,24 +67,20 @@ It is a compile-time error to discard the value of an expression if:
 * The value's type is an aggregate (a `struct`, `union`, `class`, or
   `interface`) whose declaration is annotated with `@nodiscard`.
 
-The distinction between "expression" and "value" here is significant. Consider
-the following example:
+The distinction between "expression" and "value" here is significant. In
+particular, it means that the *value* returned from a `@nodiscard`
+function may discarded as long as the function call is enclosed in some other
+*expression*; for example:
 
 ```d
-// A function that returns a @nodiscard type
-@nodiscard struct S {}
-S foo() { return S(); }
-
-// A @nodiscard function
-@nodiscard int bar() { return 0; }
-
-// Generic identity function
-T identity(T)(T value) { return value; }
+@nodiscard int func() { return 0; }
 
 void main()
 {
-    identity(foo()); // error: ignored value of @nodiscard type S
-    identity(bar()); // ok, neither identity nor int is @nodiscard
+    import std.stdio: writeln;
+
+    // no error; func() is "used" by the comma expression
+    (writeln("hi"), func());
 }
 ```
 

--- a/DIPs/1NNN-PJB.md
+++ b/DIPs/1NNN-PJB.md
@@ -4,7 +4,7 @@
 |-----------------|-----------------------------------------------------------------|
 | DIP:            | (number/id -- assigned by DIP Manager)                          |
 | Review Count:   | 0 (edited by DIP Manager)                                       |
-| Author:         | Paul Backus \<snarwin@gmail.com\>                               |
+| Author:         | Paul Backus (snarwin@gmail.com)                                 |
 | Implementation: | <https://github.com/dlang/dmd/pull/11765>                       |
 | Status:         | Will be set by the DIP manager (e.g. "Approved" or "Rejected")  |
 
@@ -13,7 +13,6 @@
 Required.
 
 Short and concise description of the idea in a few lines.
-
 
 ## Contents
 * [Rationale](#rationale)

--- a/DIPs/1NNN-PJB.md
+++ b/DIPs/1NNN-PJB.md
@@ -55,12 +55,43 @@ into errors was submitted as [issue 5464](https://issues.dlang.org/show_bug.cgi?
 [ClangWarnUnusedResult]: https://clang.llvm.org/docs/AttributeReference.html#nodiscard-warn-unused-result
 
 ## Description
-Required.
 
-Detailed technical description of the new semantics. Language grammar changes
-(per https://dlang.org/spec/grammar.html) needed to support the new syntax
-(or change) must be mentioned. Examples demonstrating the new semantics will
-strengthen the proposal and should be considered mandatory.
+### Syntax
+
+`@nodiscard` is an [attribute][Attribute] that can be applied to individual
+declarations, to a block (`@nodiscard { }`), or to all subsequent declarations
+in the current scope (`@nodiscard:`).
+
+`@nodiscard` is not a [type constructor][TypeCtor] or a [storage
+class][StorageClass].
+
+[Attribute]: https://dlang.org/spec/attribute.html
+[TypeCtor]: https://dlang.org/spec/grammar.html#TypeCtor
+[StorageClass]: https://dlang.org/spec/grammar.html#StorageClass
+
+### Semantics
+
+It is a compile-time error to discard an expression if:
+
+* It is a call to a function whose declaration is annotated with `@nodiscard`.
+* Its type is an [aggregate type][AggregateDeclaration] whose declaration is
+  annotated with `@nodiscard`.
+
+An expression is considered to be discarded if and only if:
+
+* It is the top-level *Expression* in an *ExpressionStatement*.
+* It is the *AssignExpression* on the left-hand side of a *CommaExpression*.
+
+`@nodiscard` does not modify the type of any aggregate or function it is
+applied to, and does not participate in name mangling.
+
+`@nodiscard` does not apply to declarations inside the body of a `@nodiscard`
+aggregate or function declaration.
+
+`@nodiscard` has no effect on declarations other than aggregate and function
+declarations.
+
+[AggregateDeclaration]: https://dlang.org/spec/grammar.html#AggregateDeclaration
 
 ### Grammar Changes
 

--- a/DIPs/1NNN-PJB.md
+++ b/DIPs/1NNN-PJB.md
@@ -72,47 +72,32 @@ protection against ignored errors in all of the use-cases listed above.
 
 [Dub]: https://code.dlang.org/
 
-### Almost-pure functions
+### Functions without specified side effects
 
-There are some functions that, while not being completely `pure`, are
-nevertheless extremely unlikely to ever be called solely for their side
-effects.
+Some functions have side effects, but are nevertheless unlikely to be called
+for those side effects alone. Examples of such functions include:
 
-One example of such a function is `std.format.format` when called with
-floating-point numbers as arguments. It is not `pure`, because it accesses the
-global floating-point environment, but it is extremely unlikely to ever be
-called for that purpose alone, and ignoring its return value is very likely to
-be a programming mistake.
+* Functions that acquire resources, such as `malloc` and `mmap`.
+* Functions that generate random numbers, such as `rand` and `uniform`.
+* Generic functions that may or may not cause side effects in order to produce
+  a particular result, such as `filter` and `map`.
+
+What these functions have in common is that their side effects, if any, are
+considered implementation details, rather than being part of their documented
+behavior. As a result, calling code cannot rely on them to cause any *specific*
+side effects without risking breakage if and when those implementation details
+change.
+
+While ignoring the return values of these functions is unlikely to result in
+disaster, it is still a probable programming mistake, which `@nodiscard` could
+help guard against.
 
 This DIP does not recommend adding `@nodiscard` to any existing functions in
 Phobos or the D runtime, since doing so would constitute a breaking API change.
-However, authors of new almost-`pure` functions would benefit from having
-`@nodiscard` in the language, and existing projects (including Phobos and the D
-runtime) could still adopt `@nodiscard` on a case-by-case basis if the benefit
-were judged to be worth the potential for breakage.
-
-#### Alternatives
-
-The most straightforward way to fix a function that is almost-`pure` is to make
-it *acutally* `pure`. For `pure` functions, `@nodiscard` is not necessary,
-since the D compiler already warns about discarding their return values.
-
-While this solution is ideal in theory, it is likely to be infeasible in
-practice. Many functions in Phobos and the D runtime have been known to be
-almost-`pure` for a long time (for example, impurity of floating-point to
-string conversion was pointed out in [a Bugzilla comment in
-2014][Issue7438Comment8]). That they have not yet been made completely `pure`
-suggests that there are non-trivial obstacles in the way of doing so.
-
-As long as those obstacles exist, there is an ongoing risk of new code
-stumbling into them, leading to the continued proliferation of almost-`pure`
-functions in the D ecosystem. `@nodiscard` would allow the authors of these new
-functions to, as it were, "stop the bleeding," without necessarily addressing
-the underlying cause. Later, if and when it becomes possible for them to make
-their functions completely `pure`, and the `@nodiscard` attribute is no longer
-needed, it can be safely removed.
-
-[Issue7438Comment8]: https://issues.dlang.org/show_bug.cgi?id=7438#c8
+However, authors of new code would still benefit from having `@nodiscard` in
+the language, and existing projects (including Phobos and the D runtime) could
+adopt `@nodiscard` on a case-by-case basis if the benefit were judged to be
+worth the potential for breakage.
 
 ## Prior Work
 

--- a/DIPs/1NNN-PJB.md
+++ b/DIPs/1NNN-PJB.md
@@ -51,6 +51,21 @@ Detailed technical description of the new semantics. Language grammar changes
 (or change) must be mentioned. Examples demonstrating the new semantics will
 strengthen the proposal and should be considered mandatory.
 
+### Grammar Changes
+
+```diff
+AtAttribute:
+    @ disable
+    @ nogc
+    @ live
++   @ nodiscard
+    Property
+    @ safe
+    @ system
+    @ trusted
+    UserDefinedAttribute
+```
+
 ## Breaking Changes and Deprecations
 This section is not required if no breaking changes or deprecations are anticipated.
 

--- a/DIPs/1NNN-PJB.md
+++ b/DIPs/1NNN-PJB.md
@@ -212,9 +212,9 @@ ones described above. In particular:
 
 * `@nodiscard` is not part of the type of any symbol it is applied to, and does
   not participate in name mangling.
-* `@nodiscard` does not apply to declarations inside the body of a `@nodiscard`
-  aggregate or function declaration (that is, it does not "flow through" from
-  outer scopes to inner ones).
+* A `@nodiscard` annotation on a function or aggregate declaration does not
+  apply to declarations inside that function or aggregate's body (that is,
+  `@nodiscard` does not implicitly propagate from outer scopes to inner ones).
 * `@nodiscard` has no semantic effect on declarations other than aggregate and
   function declarations.
 

--- a/DIPs/1NNN-PJB.md
+++ b/DIPs/1NNN-PJB.md
@@ -10,9 +10,13 @@
 
 ## Abstract
 
-Required.
-
-Short and concise description of the idea in a few lines.
+Ignoring the return value of a function is a common programming mistake,
+especially when it comes to functions that use their return values to signal
+errors. While exceptions allow a function to signal errors that cannot be
+ignored, using them has costs that programmers are not always able or willing
+to pay. For those use-cases where exceptions are not a good fit, this DIP
+proposes a new attribute, `@nodiscard`, that allows the programmer to make
+ignoring the return value of a function into a compile-time error.
 
 ## Contents
 * [Rationale](#rationale)

--- a/DIPs/1NNN-PJB.md
+++ b/DIPs/1NNN-PJB.md
@@ -143,6 +143,9 @@ and forums; see the [Reference](#reference) section below for details.
 
 ## Description
 
+`@nodiscard` is a compiler-recognized user-defined attribute declared in the D
+runtime module `core.attribute`. It takes no arguments.
+
 An expression is considered to be discarded if and only if either of the
 following is true:
 
@@ -215,30 +218,9 @@ ones described above. In particular:
 * `@nodiscard` has no semantic effect on declarations other than aggregate and
   function declarations.
 
-### Grammar Changes
-
-```diff
-AtAttribute:
-    @ disable
-    @ nogc
-    @ live
-+   @ nodiscard
-    Property
-    @ safe
-    @ system
-    @ trusted
-    UserDefinedAttribute
-```
-
 ## Breaking Changes and Deprecations
 
-Existing code that uses `@nodiscard` as a user-defined attribute may fail to
-compile, or may compile but have its meaning silently changed. Therefore,
-acceptance of this DIP should be followed by a deprecation period, during which
-the use of `nodiscard` as a UDA name is flagged as deprecated by the compiler.
-During the deprecation period, the command-line option `-preview=nodiscard`
-will enable the new behavior; afterward, the command-line option
-`-revert=nodiscard` will disable it.
+No breaking changes or deprecations are anticipated.
 
 ## Reference
 

--- a/DIPs/1NNN-PJB.md
+++ b/DIPs/1NNN-PJB.md
@@ -36,9 +36,9 @@ chances of the DIP being understood and carefully evaluated.
 
 The D compiler already warns about discarding the value of an expression with
 no side effects, including a call to a strongly-pure function. An attribute
-allowing the programmer to apply this warning to specific function calls and
-specific types of values has been proposed several times on the D issue tracker
-and forums; see the [Reference](#reference) section below for details.
+that would allow the programmer to mark specific functions or types as
+non-discardable has been proposed several times on the D issue tracker and
+forums; see the [Reference](#reference) section below for details.
 
 ### In Other Languages
 

--- a/DIPs/1NNN-PJB.md
+++ b/DIPs/1NNN-PJB.md
@@ -64,9 +64,9 @@ not been used (where "using" means calling a particular method). While this
 addresses some of the use-cases above, it has several shortcomings compared to
 `@nodiscard`.
 
-1. It reports ignored errors at runtime rather than compile time.
-2. It cannot be used directly with functions written in other languages.
-3. It requires additional syntax in both the callee and its callers to wrap
+* It reports ignored errors at runtime rather than compile time.
+* It cannot be used directly with functions written in other languages.
+* It requires additional syntax in both the callee and its callers to wrap
    and unwrap the error code.
 
 By contrast, `@nodiscard` can be used without caveats to provide compile-time

--- a/DIPs/1NNN-PJB.md
+++ b/DIPs/1NNN-PJB.md
@@ -35,7 +35,7 @@ exception. For a variety of reasons, however, the use of exceptions is not
 always possible or desirable. Examples of code that may want or need to avoid
 exceptions include:
 
-* Code that is written in a language other than D (e.g., C or C++).
+* Code that is written in a language other than D (for example, C or C++).
 * Code written in D that may be called from another language.
 * Code that does not want to depend on the D runtime.
 * Code that cannot afford the runtime performance overhead of exceptions.
@@ -99,8 +99,8 @@ for those side effects alone. Examples of such functions include:
 
 * Functions that acquire resources, such as `malloc` and `mmap`.
 * Functions that generate random numbers, such as `rand` and `uniform`.
-* Generic functions that may or may not cause side effects in order to produce
-  a particular result, such as `filter` and `map`.
+* Generic functions that may or may not cause side effects depending on their
+  arguments, such as `filter` and `map`.
 
 What these functions have in common is that their side effects, if any, are
 considered implementation details, rather than being part of their documented

--- a/DIPs/1NNN-PJB.md
+++ b/DIPs/1NNN-PJB.md
@@ -114,13 +114,14 @@ AtAttribute:
 ```
 
 ## Breaking Changes and Deprecations
-This section is not required if no breaking changes or deprecations are anticipated.
 
-Provide a detailed analysis on how the proposed changes may affect existing
-user code and a step-by-step explanation of the deprecation process which is
-supposed to handle breakage in a non-intrusive manner. Changes that may break
-user code and have no well-defined deprecation process have a minimal chance of
-being approved.
+Existing code that uses `@nodiscard` as a user-defined attribute may fail to
+compile, or may compile but have its meaning silently changed. Therefore,
+acceptance of this DIP should be followed by a deprecation period, during which
+the use of `nodiscard` as a UDA name is flagged as deprecated by the compiler.
+During the deprecation period, the command-line option `-preview=nodiscard`
+will enable the new behavior; afterward, the command-line option
+`-revert=nodiscard` will disable it.
 
 ## Reference
 

--- a/DIPs/1NNN-PJB.md
+++ b/DIPs/1NNN-PJB.md
@@ -30,9 +30,10 @@ that report errors via their return values.
 ### Error handling without exceptions
 
 Currently, in D, if a function wants to send a signal to its caller that the
-caller cannot ignore, the only way to do so is to throw an exception. For a
-variety of reasons, however, the use of exceptions is not always possible or
-desirable. Examples of code that may want or need to avoid exceptions include:
+caller cannot ignore, the only way to do so in general is to throw an
+exception. For a variety of reasons, however, the use of exceptions is not
+always possible or desirable. Examples of code that may want or need to avoid
+exceptions include:
 
 * Code that is written in a language other than D (e.g., C or C++).
 * Code written in D that may be called from another language.
@@ -70,6 +71,24 @@ addresses some of the use-cases above, it has several shortcomings compared to
 
 By contrast, `@nodiscard` can be used without caveats to provide compile-time
 protection against ignored errors in all of the use-cases listed above.
+
+Another alternative is for a function to return error information via
+an `out` parameter. Since a call to the function will not compile with a
+missing argument, the calling code is forced, at compile time, to visibly
+acknowledge the possibility of an error.
+
+Unfortunately, using `out` parameters for error handling is not a
+general-purpose solution, because the programmer is not always free to change a
+function's signature to include an `out` parameter. Reasons for this include:
+
+* The function is part of an external library written in another language.
+* The function is an override of a virtual function that is part of an
+  established public API.
+* The function is used as an argument to a higher-order function such as `map`
+  or `filter` that requires a particular signature.
+
+By contrast, `@nodiscard` can be used with any kind of function, because all
+functions have a return type.
 
 [Dub]: https://code.dlang.org/
 

--- a/DIPs/1NNN-PJB.md
+++ b/DIPs/1NNN-PJB.md
@@ -226,9 +226,9 @@ will enable the new behavior; afterward, the command-line option
 * [Issue 3882 - Unused result of pure functions][Issue3882]
 * [Issue 5464 - Attribute to not ignore function result][Issue5464]
 * [Issue 20165 - Add standard @nodiscard attribute for functions][Issue20165]
-* [xxxInPlace or xxxCopy?][Thread3] (D.General)
+* [xxxInPlace or xxxCopy?][Thread1] (D.General)
 * [There is anything like nodiscard attribute in D?][Thread2] (D.Learn)
-* [Idiomatic way to express errors without resorting to exceptions][Thread1]
+* [Idiomatic way to express errors without resorting to exceptions][Thread3]
   (D.Learn)
 * [Vladimir Panteleev's `Success` type.][SuccessType]
 

--- a/DIPs/1NNN-PJB.md
+++ b/DIPs/1NNN-PJB.md
@@ -33,6 +33,17 @@ chances of the DIP being understood and carefully evaluated.
 
 ## Prior Work
 
+### In D
+
+The D compiler already warns about discarding the value of an expression with
+no side effects, including the return value of a `pure` function. Several
+possible enhancements to this feature were discussed in the comments on [issue
+3882](https://issues.dlang.org/show_bug.cgi?id=3882), and an enhancement
+request for a `@nodiscard` attribute that would turn discarded return values
+into errors was submitted as [issue 5464](https://issues.dlang.org/show_bug.cgi?id=5464).
+
+### In Other Languages
+
 * C++17's [`[[nodiscard]]` attribute][Cpp17Nodiscard].
 * Rust's [`#[must_use]` attribute][RustMustUse].
 * GCC's [`warn_unused_result` attribute][GccWarnUnusedResult].

--- a/DIPs/1NNN-PJB.md
+++ b/DIPs/1NNN-PJB.md
@@ -73,14 +73,31 @@ function may discarded as long as the function call is enclosed in some other
 *expression*; for example:
 
 ```d
-@nodiscard int func() { return 0; }
+struct Result { int n; }
+@nodiscard Result func() { return Result(0); }
 
 void main()
 {
     import std.stdio: writeln;
 
-    // no error; func() is "used" by the comma expression
-    (writeln("hi"), func());
+    // no error; return value of func is "used" by the comma expression
+    (writeln("side effect"), func());
+}
+```
+
+However, this is not possible if `@nodiscard` is applied to the return type
+instead of the function:
+
+```d
+@nodiscard struct Result { int n; }
+Result func() { return Result(0); }
+
+void main()
+{
+    import std.stdio: writeln;
+
+    // error; value of comma expression is @nodiscard, because it is a Result
+    (writeln("side effect"), func());
 }
 ```
 

--- a/DIPs/1NNN-PJB.md
+++ b/DIPs/1NNN-PJB.md
@@ -71,10 +71,10 @@ It is a compile-time error to discard the value of an expression if:
 * The value's type is an aggregate (a `struct`, `union`, `class`, or
   `interface`) whose declaration is annotated with `@nodiscard`.
 
-The distinction between "expression" and "value" here is significant. In
-particular, it means that the *value* returned from a `@nodiscard`
-function may discarded as long as the function call is enclosed in some other
-*expression*; for example:
+The distinction between "expression" and "value" in this definition is
+significant. In particular, it means that the *value* returned from a
+`@nodiscard` function may discarded as long as the function call is enclosed in
+some other *expression*; for example:
 
 ```d
 struct Result { int n; }
@@ -84,12 +84,14 @@ void main()
 {
     import std.stdio: writeln;
 
-    // no error; return value of func is "used" by the comma expression
+    // no error:
+    //   - return value of func is "used" by the comma expression
+    //   - writeln is not pure, so the comma expression can be discarded
     (writeln("side effect"), func());
 }
 ```
 
-However, this is not possible if `@nodiscard` is applied to the return type
+By contrast, this is not possible if `@nodiscard` is applied to the return type
 instead of the function:
 
 ```d
@@ -100,21 +102,21 @@ void main()
 {
     import std.stdio: writeln;
 
-    // error; value of comma expression is @nodiscard, because it is a Result
+    // error: value of comma expression is a Result, which cannot be discarded
     (writeln("side effect"), func());
 }
 ```
 
-Using `@nodiscard` has no effects on a program other than the ones described
-above. In particular:
+Using `@nodiscard` has no effects on the semantics of a program other than the
+ones described above. In particular:
 
 * `@nodiscard` does not affect the type of any aggregate or function it is
   applied to, and does not participate in name mangling.
 * `@nodiscard` does not apply to declarations inside the body of a `@nodiscard`
   aggregate or function declaration (that is, it does not "flow through" from
   outer scopes to inner ones).
-* `@nodiscard` has no effect on declarations other than aggregate and function
-  declarations.
+* `@nodiscard` has no semantic effect on declarations other than aggregate and
+  function declarations.
 
 ### Grammar Changes
 

--- a/DIPs/1NNN-PJB.md
+++ b/DIPs/1NNN-PJB.md
@@ -36,11 +36,10 @@ chances of the DIP being understood and carefully evaluated.
 ### In D
 
 The D compiler already warns about discarding the value of an expression with
-no side effects, including the return value of a `pure` function. Several
-possible enhancements to this feature were discussed in the comments on [issue
-3882](https://issues.dlang.org/show_bug.cgi?id=3882), and an enhancement
-request for a `@nodiscard` attribute that would turn discarded return values
-into errors was submitted as [issue 5464](https://issues.dlang.org/show_bug.cgi?id=5464).
+no side effects, including a call to a strongly-pure function. An attribute
+allowing the programmer to apply this warning to specific function calls and
+specific types of values has been proposed several times on the D issue tracker
+and forums; see the [Reference](#reference) section below for details.
 
 ### In Other Languages
 
@@ -118,8 +117,21 @@ user code and have no well-defined deprecation process have a minimal chance of
 being approved.
 
 ## Reference
-Optional links to reference material such as existing discussions, research papers
-or any other supplementary materials.
+
+* [Issue 3882 - Unused result of pure functions][Issue3882]
+* [Issue 5464 - Attribute to not ignore function result][Issue5464]
+* [Issue 20165 - Add standard @nodiscard attribute for functions][Issue20165]
+* [xxxInPlace or xxxCopy?][Thread3] (D.General)
+* [There is anything like nodiscard attribute in D?][Thread2] (D.Learn)
+* [Idiomatic way to express errors without resorting to exceptions][Thread1]
+  (D.Learn)
+
+[Issue3882]: https://issues.dlang.org/show_bug.cgi?id=3882
+[Issue5464]: https://issues.dlang.org/show_bug.cgi?id=5464
+[Issue20165]: https://issues.dlang.org/show_bug.cgi?id=20165
+[Thread1]: https://forum.dlang.org/thread/ih7sfi$1q6f$1@digitalmars.com
+[Thread2]: https://forum.dlang.org/thread/rzfshzfrxrlbxyvcngke@forum.dlang.org
+[Thread3]: https://forum.dlang.org/thread/hhpqmifgjslpzbzfauab@forum.dlang.org
 
 ## Copyright & License
 Copyright (c) 2020 by the D Language Foundation

--- a/DIPs/1NNN-PJB.md
+++ b/DIPs/1NNN-PJB.md
@@ -55,42 +55,49 @@ and forums; see the [Reference](#reference) section below for details.
 
 ## Description
 
-### Syntax
-
-`@nodiscard` is an [attribute][Attribute] that can be applied to individual
-declarations, to a block (`@nodiscard { }`), or to all subsequent declarations
-in the current scope (`@nodiscard:`).
-
-`@nodiscard` is not a [type constructor][TypeCtor] or a [storage
-class][StorageClass].
-
-[Attribute]: https://dlang.org/spec/attribute.html
-[TypeCtor]: https://dlang.org/spec/grammar.html#TypeCtor
-[StorageClass]: https://dlang.org/spec/grammar.html#StorageClass
-
-### Semantics
-
-It is a compile-time error to discard an expression if:
-
-* It is a call to a function whose declaration is annotated with `@nodiscard`.
-* Its type is an [aggregate type][AggregateDeclaration] whose declaration is
-  annotated with `@nodiscard`.
-
 An expression is considered to be discarded if and only if:
 
 * It is the top-level *Expression* in an *ExpressionStatement*.
 * It is the *AssignExpression* on the left-hand side of a *CommaExpression*.
 
-`@nodiscard` does not modify the type of any aggregate or function it is
-applied to, and does not participate in name mangling.
+It is a compile-time error to discard the value of an expression if:
 
-`@nodiscard` does not apply to declarations inside the body of a `@nodiscard`
-aggregate or function declaration.
+* The expression is a call to a function whose declaration is annotated with
+  `@nodiscard`.
+* The value's type is an aggregate (a `struct`, `union`, `class`, or
+  `interface`) whose declaration is annotated with `@nodiscard`.
 
-`@nodiscard` has no effect on declarations other than aggregate and function
-declarations.
+The distinction between "expression" and "value" here is significant. Consider
+the following example:
 
-[AggregateDeclaration]: https://dlang.org/spec/grammar.html#AggregateDeclaration
+```d
+// A function that returns a @nodiscard type
+@nodiscard struct S {}
+S foo() { return S(); }
+
+// A @nodiscard function
+@nodiscard int bar() { return 0; }
+
+// Generic identity function
+T identity(T)(T value) { return value; }
+
+void main()
+{
+    identity(foo()); // error: ignored value of @nodiscard type S
+    identity(bar()); // ok, neither identity nor int is @nodiscard
+}
+```
+
+Using `@nodiscard` has no effects on a program other than the ones described
+above. In particular:
+
+* `@nodiscard` does not affect the type of any aggregate or function it is
+  applied to, and does not participate in name mangling.
+* `@nodiscard` does not apply to declarations inside the body of a `@nodiscard`
+  aggregate or function declaration (that is, it does not "flow through" from
+  outer scopes to inner ones).
+* `@nodiscard` has no effect on declarations other than aggregate and function
+  declarations.
 
 ### Grammar Changes
 

--- a/DIPs/1NNN-PJB.md
+++ b/DIPs/1NNN-PJB.md
@@ -1,0 +1,75 @@
+# @nodiscard
+
+| Field           | Value                                                           |
+|-----------------|-----------------------------------------------------------------|
+| DIP:            | (number/id -- assigned by DIP Manager)                          |
+| Review Count:   | 0 (edited by DIP Manager)                                       |
+| Author:         | Paul Backus \<snarwin@gmail.com\>                               |
+| Implementation: | <https://github.com/dlang/dmd/pull/11765>                       |
+| Status:         | Will be set by the DIP manager (e.g. "Approved" or "Rejected")  |
+
+## Abstract
+
+Required.
+
+Short and concise description of the idea in a few lines.
+
+
+## Contents
+* [Rationale](#rationale)
+* [Prior Work](#prior-work)
+* [Description](#description)
+* [Breaking Changes and Deprecations](#breaking-changes-and-deprecations)
+* [Reference](#reference)
+* [Copyright & License](#copyright--license)
+* [Reviews](#reviews)
+
+## Rationale
+Required.
+
+A short motivation about the importance and benefits of the proposed change.  An existing,
+well-known issue or a use case for an existing projects can greatly increase the
+chances of the DIP being understood and carefully evaluated.
+
+## Prior Work
+
+* C++17's [`[[nodiscard]]` attribute][Cpp17Nodiscard].
+* Rust's [`#[must_use]` attribute][RustMustUse].
+* GCC's [`warn_unused_result` attribute][GccWarnUnusedResult].
+* Clang's [`warn_unused_result` attribute][ClangWarnUnusedResult].
+
+[Cpp17Nodiscard]: https://en.cppreference.com/w/cpp/language/attributes/nodiscard
+[RustMustUse]: https://doc.rust-lang.org/reference/attributes/diagnostics.html#the-must_use-attribute
+[GccWarnUnusedResult]: https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#Common-Function-Attributes
+[ClangWarnUnusedResult]: https://clang.llvm.org/docs/AttributeReference.html#nodiscard-warn-unused-result
+
+## Description
+Required.
+
+Detailed technical description of the new semantics. Language grammar changes
+(per https://dlang.org/spec/grammar.html) needed to support the new syntax
+(or change) must be mentioned. Examples demonstrating the new semantics will
+strengthen the proposal and should be considered mandatory.
+
+## Breaking Changes and Deprecations
+This section is not required if no breaking changes or deprecations are anticipated.
+
+Provide a detailed analysis on how the proposed changes may affect existing
+user code and a step-by-step explanation of the deprecation process which is
+supposed to handle breakage in a non-intrusive manner. Changes that may break
+user code and have no well-defined deprecation process have a minimal chance of
+being approved.
+
+## Reference
+Optional links to reference material such as existing discussions, research papers
+or any other supplementary materials.
+
+## Copyright & License
+Copyright (c) 2020 by the D Language Foundation
+
+Licensed under [Creative Commons Zero 1.0](https://creativecommons.org/publicdomain/zero/1.0/legalcode.txt)
+
+## Reviews
+The DIP Manager will supplement this section with a summary of each review stage
+of the DIP process beyond the Draft Review.
+


### PR DESCRIPTION
> ## Abstract
> 
> This DIP proposes a new attribute, `@nodiscard`, that allows the programmer to
> make ignoring a function's return value into a compile-time error. It can be
> used to implement alternative error-handling mechanisms for code that cannot
> use exceptions, and to prevent bugs when interfacing with external functions
> that report errors via their return values.