### PR TITLE
[New DIP] Token-based Mixins

### DIFF
--- a/DIPs/DIP-1NN2-QFS.md
+++ b/DIPs/DIP-1NN2-QFS.md
@@ -195,13 +195,17 @@ In `Tokens ;` Tokens may include `;` only in unbalanced braces. The first semico
 
 MixinStatement:
         mixin ( ArgumentList ) ;
-+       mixin [ TokenMixinArguments ,opt ] { Tokens }
-+       mixin [ TokenMixinArguments ,opt ] Tokens ;
++       mixin [ TokenMixinArguments , ] { Tokens }
++       mixin [ TokenMixinArguments   ] { Tokens }
++       mixin [ TokenMixinArguments , ] Tokens ;
++       mixin [ TokenMixinArguments   ] Tokens ;
 
     MixinDeclaration:
         mixin ( ArgumentList ) ;
-+       mixin [ TokenMixinArguments ,opt ] { Tokens }
-+       mixin [ TokenMixinArguments ,opt ] Tokens ;
++       mixin [ TokenMixinArguments , ] { Tokens }
++       mixin [ TokenMixinArguments   ] { Tokens }
++       mixin [ TokenMixinArguments , ] Tokens ;
++       mixin [ TokenMixinArguments   ] Tokens ;
 
     MixinExpression:
         mixin ( ArgumentList )

--- a/DIPs/DIP-1NN2-QFS.md
+++ b/DIPs/DIP-1NN2-QFS.md
@@ -1,0 +1,229 @@
+# Token-based Mixins
+
+| Field           | Value                                                           |
+|-----------------|-----------------------------------------------------------------|
+| DIP:            | *TBD by DIP Manager*                                            |
+| Review Count:   | 0 (edited by DIP Manager)                                       |
+| Author:         | Quirin F. Schroll (q.schroll@gmail.com)                         |
+| Implementation: | *none*                                                          |
+| Status:         | Draft                                                           |
+
+## Abstract
+
+The author suggests adding another way to express mixin statements and declarations based on
+the way `q{}` string literals are handled.
+The goal is to make meta-programming code more readabe by giving the programmers a way to write idiomatic `mixin` code
+that is easier to write correctly, review and debug.
+
+Notably, it enables using idiomatic pseudo code found in the D Language Specification to become actual code.
+
+## Contents
+* [Rationale](#rationale)
+* [Prior Work](#prior-work)
+* [Description](#description)
+* [Breaking Changes and Deprecations](#breaking-changes-and-deprecations)
+* [Reference](#reference)
+* [Copyright & License](#copyright--license)
+* [Reviews](#reviews)
+
+## Rationale
+
+In meta-programming, mixin declarations and statements are often used in conjunction with large literals containing code,
+where dynamic code parts are inserted at specific points in string literals (code templates) using interruptions like
+```D
+mixin("...", identifier, "...");
+```
+or
+```D
+mixin("...%s...".format(..., identifier, ...));
+```
+That impairs readability greatly.
+The language should allow for code that directly express what the programmer means.
+
+In those cases, progrmmers mean: Insert the value of `identifier` and not literal `"identifier"` here.
+Another observation is also that hardly anywhere, the value of `identifier` and the string  `"identifier"` are needed together.
+
+In the interruption case, the `", identifer, "` potions interrupt the code with much noise.
+It also reduces the potential of using `q{}` strings since inside them, braces need to be balanced,
+therefore the `q{}` string cannot be interrupted at any place.
+
+In the `format` case, holes mostly look like `%s` and there is no way to visually match them with their intended replacements.
+Also, adding, reordering or removing holes necessitates an according change of the processing function's arguments.
+To the author, there seems to be a split in coding practices for the case where more than one hole is to be filled with the same content,
+whether to use `%1$s` specifiers in the template string or merely `%s` and repeat the argument.
+This addition solves this issue without imposing a choice for which choice is the least bad one.
+
+Syntax highlighting is ususually not available for string literals that are indended to be used as code.
+
+## Prior Work
+There are several proposals to add interpolated strings.
+
+String interpolation solves one of the problems tackeld by this DIP, but not all of them.
+The author believes that string interpolation is a great addition for generating string literals at runtime,
+but this addition is superior for code generation.
+Even when string interpolation is added to the language, this addition will be worth the efforts implementing and maintaining it.
+
+## Description
+The DIP suggests adding another way to write mixin statements and declarations, notably absent are mixin expressions.
+Since readers may not be familiar with the distinction, a brief summary of the terms *mixin statements, declarations,* and *expressions* is given at the end of this section.
+
+Currently, the `mixin` keyword can be followd by an opening parenthesis constituting a mixin statement, declaration, or expression,
+depending on the context the keyword occurs in;
+or be followed by an identifier constituting a mixin template instantiation.
+
+The DIP suggests adding another case:
+When the `mixin` keyword is followed by an opening bracket, it introduces a token-based mixin declaration or statement, depending on the context the keyword occurs in.
+Between brackets, a comma-separated list of possibly assigned identifiers follows.
+Between braces, any tokens can be entered with special treatment of brace tokens that nest the same way they nest in `q{}` literals.
+If no opening brace follows, any tokens can be entered with special treatment of brace tokens that nest the same way they nest in `q{}` literals,
+but tokens are considered up to the next semicolon not nested in braces.
+This is so that token-based mixins can be used to define lambda expressions with the brace syntax.
+
+Every token and all white space between the braces is being replaced by a string literal containing the token or white space,
+except for identifier tokens that coincide with one of the identifiers listed between the braces;
+in that case, the idientifer token remains unchanged.
+These string literal and identifer expressions are being concatenated and the result of the concatenation mixed in.
+
+As an easy to follow example, consider
+```D
+mixin[op] lhs op= rhs;
+```
+or
+```D
+mixin[op]
+{
+    lhs.a op= rhs.a;
+    lhs.b op= rhs.b;
+}
+```
+as part of an `opOpAssign` implementation.
+It is equivalent to
+```D
+mixin("lhs ", op, "= rhs;");
+```
+or
+```D
+mixin("lhs.a ", op, "= rhs.a;");
+mixin("lhs.b ", op, "= rhs.b;");
+```
+Here, `op` is marked not to be replaced by `"op"`.
+Notice that when `op` happens to be `"+"` for example, the resulting `+=` constitutes a single D token.
+
+Use case for the use case of the assignment:
+```D
+auto opUnary(string op)() const
+if (op == "++" || op == "--")
+{
+    mixin[o = op[0]]
+        this o= 1;
+}
+```
+
+Another use case that shows how idiomatic that usage is:
+```D
+struct TrivialProperty(T)
+{
+    template opDispatch(string name)
+    {
+        mixin template opDispatch(X = T)
+        {
+            mixin[name, _name = '_' ~ name]
+            {
+                private X _name;
+                public X name() { return _name; }
+                public void name(X value) { _name = value; }
+            }
+        }
+    }
+}
+
+unittest
+{
+    struct Point
+    {
+        mixin TrivialProperty!int.x;
+        mixin TrivialProperty!int.y;
+    }
+    // Point has _x and _y as private backing fields,
+    // as well as getters and setters for x and y.
+}
+```
+
+
+The unbalanced braces in the semicolon-ended token-based mixin is demonstrated by this:
+```D
+auto opBinary(string op)(...)
+{
+    enum value = mixin[op] (ref v) { return v op 1; } (10 op 2);
+    //                     ––––––––––––––––––––––––––––––––––––
+
+    // Equivalent to:
+    enum value = mixin("(ref v) { return v ", op, " 1; } (10 ", op, " 2);");
+}
+```
+The tokens that are part of the mixed-in are the ones above dashes.
+The semicolon after `1` does not end the token scan, since the opening brace before `return` is not closed yet.
+
+### About Mixin Statements, Declarations, and Expressions
+
+Mixin statements, declarations, and expressions are all introduced by the `mixin` keyword.
+They deal with inserting code that is derived from compile-time known string expressions.
+They have nothing to do with `mixin template` constructions that insert symbols.
+The difference between mixin statements, declarations, and expressions is only where the `mixin` keyword is used:
+* Mixin declarations happen when `mixin` is used in a scope that contains delarations, such as module scope or inside the `struct`, `union`, `class`, and `interface` definition blocks.
+* Mixin statements and expressions happen when `mixin` is used inside function blocks.
+    * Mixin statements generate whole statements so the code generated must include `;` at the end.
+    * Mixin expressions generate parts of expressions and the code generated must not include `;` at the end.
+To many programmers, the distinction of mixin definitions and statements is practically irrelevant.
+The distinction of mixin statements and expressions is relevant insofar as a trailing semicolon has to be accounted for:
+for example, `return mixin("result");` is a statement containing a mixin expression, but `mixin("return result;");` is a mixin statement.
+
+### Grammar changes
+
+In the following, `Tokens` means slightliy differnt things.
+In `{ Tokens }`, braces must be balanced, similar to `q{}` strings.
+In `Tokens ;` Tokens may include `;` only in unbalanced braces. The first semicolon encountered after balanced braces or before any braces is not part of `Tokens`.
+
+```diff
++   TokenMixinArguments:
++       TokenMixinArgument
++       TokenMixinArgument , TokenMixinArguments
+
++   TokenMixinArgument:
++       Identifier
++       Identifier = AssignExpression
+
+MixinStatement:
+        mixin ( ArgumentList ) ;
++       mixin [ TokenMixinArguments ,opt ] { Tokens }
++       mixin [ TokenMixinArguments ,opt ] Tokens ;
+
+    MixinDeclaration:
+        mixin ( ArgumentList ) ;
++       mixin [ TokenMixinArguments ,opt ] { Tokens }
++       mixin [ TokenMixinArguments ,opt ] Tokens ;
+
+    MixinExpression:
+        mixin ( ArgumentList )
+
+    MixinType:
+        mixin ( ArgumentList )
+```
+
+The entries for `MixinExpression` and `MixinType` are unchanged and only mentioned to
+anticipate confusion. Token mixins are always statements or declarations and never expressions.
+
+## Breaking Changes and Deprecations
+Since the additions of this change are a syntactic addition, code breakage is impossible.
+
+## Reference
+[Forum post suggesting this DIP](https://forum.dlang.org/post/vmcgpbjqimzpiiqsyyfk@forum.dlang.org)
+
+## Copyright & License
+Copyright © 2020 by the D Language Foundation
+
+Licensed under [Creative Commons Zero 1.0](https://creativecommons.org/publicdomain/zero/1.0/legalcode.txt)
+
+## Reviews
+The DIP Manager will supplement this section with a summary of each review stage
+of the DIP process beyond the Draft Review.

--- a/DIPs/DIP-1NN2-QFS.md
+++ b/DIPs/DIP-1NN2-QFS.md
@@ -10,16 +10,23 @@
 
 ## Abstract
 
-The author suggests adding another way to express mixin statements and declarations based on
-the way `q{}` string literals are handled.
-The goal is to make meta-programming code more readabe by giving the programmers a way to write idiomatic `mixin` code
-that is easier to write correctly, review and debug.
+In meta-programming, mixins are the ultimate answer of kings:
+Almost anything that can be thought of can be achieved using them.
+However, programmers abstain from mixins because non-trivial mixin code is harder to maintain.
+One pays the price of kings, so to speak.
+This DIP tries to lower that price.
 
-Notably, it enables using idiomatic pseudo code found in the D Language Specification to become actual code.
+The author suggests adding another way to express mixin statements and mixin declarations
+for the case where the code consists of a large pattern with a few open spots.
+It token-based mostly the same way `q{}` string literals are token-based.
+The goal is to make meta-programming code more readabe by giving the programmers a way to write idiomatic `mixin` code
+that is easier to write correctly and so easier to review and debug.
+
+Notably, it enables using idiomatic pseudo-code found in the D Language Specification to become actual code.
 
 ## Contents
 * [Rationale](#rationale)
-* [Prior Work](#prior-work)
+* [Prior Work / Alternatives](#prior-work--alternatives)
 * [Description](#description)
 * [Breaking Changes and Deprecations](#breaking-changes-and-deprecations)
 * [Reference](#reference)
@@ -28,51 +35,64 @@ Notably, it enables using idiomatic pseudo code found in the D Language Specific
 
 ## Rationale
 
-In meta-programming, mixin declarations and statements are often used in conjunction with large literals containing code,
-where dynamic code parts are inserted at specific points in string literals (code templates) using interruptions like
+Mixin declarations and statements are often used in conjunction with large string literals containing code,
+where a few code parts need to vary and are inserted at specific points between string literals.
+One common way is interrupting the literal using commas:
 ```D
-mixin("...", identifier, "...");
+mixin("...pattern...", hole, "...pattern...");
 ```
-or
+This will be referred to as the _interruption pattern_ in this DIP.
+
+Another is Phobos' `format` function like this:
 ```D
-mixin("...%s...".format(..., identifier, ...));
+mixin("...pattern...%s...pattern...".format(holes...));
 ```
-That impairs readability greatly.
-The language should allow for code that directly express what the programmer means.
+This will be referred to as the _replacement pattern_ in this DIP.
 
-In those cases, progrmmers mean: Insert the value of `identifier` and not literal `"identifier"` here.
-Another observation is also that hardly anywhere, the value of `identifier` and the string  `"identifier"` are needed together.
+In both cases, progrmmers usually mean to insert the value of some `identifier` and not literal `"identifier"` in a large block of code.
+The DIP proposes a solution such that `identifier` can used where its value is supposed to go without any noise or aberration.
+The case where the value of `identifier` and the string  `"identifier"` are needed together is also covered by this DIP using replacement assignments.
+Sometimes it is a syntactically short function call instead of an identifer.
+If the result of such a function call can be given a comprehensive name, which is usually the case, it is also covered by replacement assignments.
 
-In the interruption case, the `", identifer, "` potions interrupt the code with much noise.
-It also reduces the potential of using `q{}` strings since inside them, braces need to be balanced,
-therefore the `q{}` string cannot be interrupted at any place.
+In the author's view, both patterns impair code comprehension greatly:
+* In the interruption pattern, the `", identifer, "` potions interrupt the code with much noise compared to what is achieved.
+Using `q{}` strings most syntax highlighter keep code visually appealing. Because braces need to be balanced inside them,
+a `q{}` string cannot be interrupted at any place, which greatly limits their applicability for generating
+function blocks, aggregate types like structs and classes or control structurs like `if`s or loops using interruptions.
 
-In the `format` case, holes mostly look like `%s` and there is no way to visually match them with their intended replacements.
-Also, adding, reordering or removing holes necessitates an according change of the processing function's arguments.
+* In the replacement pattern, holes mostly look like `%s` and there is no way to visually match them with their intended replacements.
+While writing such code is not too hard (in the opinion of the DIP author), understanding and maintaining it is:
+Adding, reordering or removing holes necessitates an according change of the processing function's arguments.
 To the author, there seems to be a split in coding practices for the case where more than one hole is to be filled with the same content,
-whether to use `%1$s` specifiers in the template string or merely `%s` and repeat the argument.
-This addition solves this issue without imposing a choice for which choice is the least bad one.
+whether to use `%1$s` specifiers or merely `%s` and repeat the argument.
 
 Syntax highlighting is ususually not available for string literals that are indended to be used as code.
+The only exception being `q{}` strings that, as has been argued, are not an option in many important use cases.
 
-## Prior Work
+## Prior Work / Alternatives
 There are several proposals to add interpolated strings.
+String interpolation can be thought of as an alternative,
+since it solves the problems tackeld by this DIP partially.
 
-String interpolation solves one of the problems tackeld by this DIP, but not all of them.
+With interpolation, code is still in string literals.
+
 The author believes that string interpolation is a great addition for generating string literals at runtime,
 but this addition is superior for code generation.
 Even when string interpolation is added to the language, this addition will be worth the efforts implementing and maintaining it.
 
 ## Description
 The DIP suggests adding another way to write mixin statements and declarations, notably absent are mixin expressions.
-Since readers may not be familiar with the distinction, a brief summary of the terms *mixin statements, declarations,* and *expressions* is given at the end of this section.
+Since readers may not be familiar with the distinction, a brief summary of the terms
+*mixin statements, declarations,* and *expressions* is given at the end of this section.
 
-Currently, the `mixin` keyword can be followd by an opening parenthesis constituting a mixin statement, declaration, or expression,
+Currently, the `mixin` keyword can be followd by an opening parenthesis, constituting a mixin statement, declaration, or expression,
 depending on the context the keyword occurs in;
-or be followed by an identifier constituting a mixin template instantiation.
+or it can be followed by an identifier, constituting a mixin template instantiation.
 
-The DIP suggests adding another case:
-When the `mixin` keyword is followed by an opening bracket, it introduces a token-based mixin declaration or statement, depending on the context the keyword occurs in.
+The DIP suggests adding another case, the token-based mixin:
+When the `mixin` keyword is followed by an opening (square) bracket, it constitutes a token-based mixin declaration or statement,
+depending on the context the keyword occurs in.
 Between brackets, a comma-separated list of possibly assigned identifiers follows.
 Between braces, any tokens can be entered with special treatment of brace tokens that nest the same way they nest in `q{}` literals.
 If no opening brace follows, any tokens can be entered with special treatment of brace tokens that nest the same way they nest in `q{}` literals,
@@ -103,13 +123,13 @@ mixin("lhs ", op, "= rhs;");
 ```
 or
 ```D
-mixin("lhs.a ", op, "= rhs.a;");
-mixin("lhs.b ", op, "= rhs.b;");
+mixin("lhs.a ", op, "= rhs.a;
+       lhs.b ", op, "= rhs.b;");
 ```
-Here, `op` is marked not to be replaced by `"op"`.
+In both examples, `op` is marked not to be replaced by the string `"op"`, but the value of `op`.
 Notice that when `op` happens to be `"+"` for example, the resulting `+=` constitutes a single D token.
 
-Use case for the use case of the assignment:
+The usage of the assignment is demonstated here:
 ```D
 auto opUnary(string op)() const
 if (op == "++" || op == "--")
@@ -148,9 +168,10 @@ unittest
     // as well as getters and setters for x and y.
 }
 ```
+(Notice that `X = T` is not a feature.
+Leaving it out and replacing `X` by `T` lead to compiler errors at the time of the writing of this DIP.)
 
-
-The unbalanced braces in the semicolon-ended token-based mixin is demonstrated by this:
+The _semicolons in unbalanced braces rule_ is necessary to handle otherwise surprising cases correctly.
 ```D
 auto opBinary(string op)(...)
 {
@@ -161,8 +182,8 @@ auto opBinary(string op)(...)
     enum value = mixin("(ref v) { return v ", op, " 1; } (10 ", op, " 2);");
 }
 ```
-The tokens that are part of the mixed-in are the ones above dashes.
-The semicolon after `1` does not end the token scan, since the opening brace before `return` is not closed yet.
+The tokens that are part of the mixin expressions are the ones above dashes.
+The semicolon after `1` does not end the mixin expression, since the opening brace before `return` is not closed yet.
 
 ### About Mixin Statements, Declarations, and Expressions
 
@@ -172,8 +193,8 @@ They have nothing to do with `mixin template` constructions that insert symbols.
 The difference between mixin statements, declarations, and expressions is only where the `mixin` keyword is used:
 * Mixin declarations happen when `mixin` is used in a scope that contains delarations, such as module scope or inside the `struct`, `union`, `class`, and `interface` definition blocks.
 * Mixin statements and expressions happen when `mixin` is used inside function blocks.
-    * Mixin statements generate whole statements so the code generated must include `;` at the end.
-    * Mixin expressions generate parts of expressions and the code generated must not include `;` at the end.
+    * Mixin statements are whole statements so the mixed-in string must include `;` at the end.
+    * Mixin expressions are expressions and the the mixed-in string must not include `;` at the end.
 To many programmers, the distinction of mixin definitions and statements is practically irrelevant.
 The distinction of mixin statements and expressions is relevant insofar as a trailing semicolon has to be accounted for:
 for example, `return mixin("result");` is a statement containing a mixin expression, but `mixin("return result;");` is a mixin statement.
@@ -193,7 +214,7 @@ In `Tokens ;` Tokens may include `;` only in unbalanced braces. The first semico
 +       Identifier
 +       Identifier = AssignExpression
 
-MixinStatement:
+    MixinStatement:
         mixin ( ArgumentList ) ;
 +       mixin [ TokenMixinArguments , ] { Tokens }
 +       mixin [ TokenMixinArguments   ] { Tokens }
@@ -215,7 +236,8 @@ MixinStatement:
 ```
 
 The entries for `MixinExpression` and `MixinType` are unchanged and only mentioned to
-anticipate confusion. Token mixins are always statements or declarations and never expressions.
+show that they are intetionally unchanged.
+Token-based mixins are always statements or declarations and never expressions.
 
 ## Breaking Changes and Deprecations
 Since the additions of this change are a syntactic addition, code breakage is impossible.


### PR DESCRIPTION
The syntax `lhs op= rhs` is so fundamentally understandable that it is in the spec. Still, it is not real D syntax. The thing that comes closest is `mixin("lhs", op, "= rhs;");`.

Token-based mixins are yet another form of string mixin that—from the perspective of the programmer—goes not the route of putting code in strings and interpreting that string back to code, but sets code as the default and only replaces identifiers by code in strings where marked. By `mixin[op]` we mark `op` in the following to be not part of the generated code, but the string value of `op` (e.g. if `op` is `"+"`). So
```D
mixin[op] lhs op= rhs;
```
becomes
```D
lhs += rhs;
```
and
```D
mixin[op]
{
    lhs.a op= rhs.a;
    lhs.b op= rhs.b;
}
```
becomes
```D
lhs.a += rhs.a;
lhs.b += rhs.b;
```
after the lowering.

* It only works for whole statements or declarations, not subexpressions.
* It is single statement/delcaration up to closing semicolon (first example above)
* It is multi-statement/delcaration up to closing brace.