### PR TITLE
[Fix] Change status in the document

### DIFF
--- a/DIPs/accepted/DIP1024.md
+++ b/DIPs/accepted/DIP1024.md
@@ -6,7 +6,7 @@
 | Review Count:   | 3                                                               |
 | Author:         | Walter Bright walter@digitalmars.com                            |
 | Implementation: | https://github.com/dlang/dmd/pull/10209                         |
-| Status:         | Formal Assessment                                               |
+| Status:         | Accepted                                                        |
 
 ## Abstract
 


### PR DESCRIPTION
Status in the table in the beginning of the DIP document wasn't changed when the DIP was accepted.