### PR TITLE
Update DIP1035 after Community Review Round 1

### DIFF
--- a/DIPs/DIP1035.md
+++ b/DIPs/DIP1035.md
@@ -508,7 +508,12 @@ The new trait `__traits(isSafe, x)` returns a boolean:
 
 ### Grammar changes
 
-There are no proposed grammar changes, since placing `@system` annotations is already allowed in the places where it's needed for this DIP.
+Placing `@system` annotations is already allowed in the places where it's needed for this DIP.
+The only grammar change is the addition of a traits keyword:
+```diff
+TraitsKeyword:
++    isSafe
+```
 
 ## Alternatives
 

--- a/DIPs/DIP1035.md
+++ b/DIPs/DIP1035.md
@@ -172,29 +172,32 @@ The same general pattern occurs with other user-defined types that attempt to im
 
 Allowing fields of an aggregate to be marked `@system` helps the compiler *maintain* run-time invariants on user-defined types, but it is also important to ensure the variable was not constructed with an unsafe value to begin with.
 Constructing unsafe values in a `@safe` function is not allowed, and constructing them in `@system` or `@trusted` functions leaves the responsibility of memory safety up to the programmer.
-However, it is currently possible to construct unsafe global variables and use them in `@safe` functions.
-This not only applies to user-defined types, but also built-in types:
+When accessing global variables of an unsafe type in a `@safe` function, the compiler should be either conservative and reject any access, or do basic [taint-checking](https://en.wikipedia.org/wiki/Taint_checking):
 ```D
 int* x = cast(int*) 0xDEADBEEF;
+extern int* y;
+int* z = new int(20);
+
 void main() @safe
 {
-    *x = 10;
+    *x = 10; // Not allowed
+    *y = 10; // Not allowed
+    *z = 10; // Maybe allowed
 }
 ```
-Since the initialization expression `cast(int*) 0xDEADBEEF` would not be allowed in a `@safe` function, the compiler should annotate variable `x` as possibly containing an unsafe value, so it may not be accessed in a `@safe` function.
-This is similar to [Taint-checking](https://en.wikipedia.org/wiki/Taint_checking).
-While in this case the 'may contain unsafe value' annotation is inferred and could remain internal to the compiler, there are cases where the programmer might want to help the compiler with this annotation:
-- The global variable is `extern`
-- The global variable is not of an unsafe type but still has run-time invariants
-- The initialization expression is `@system` but the programmer knows the resulting value is safe.
+Since the initialization expression `cast(int*) 0xDEADBEEF` would not be allowed in a `@safe` function, and since the initial value of `y` is unknown, the compiler should annotate variables `x` and `y` as possibly containing an unsafe value, so they cannot be accessed in a `@safe` function.
+Only `z` is known to have a safe initial value in this case, so the compiler could allow access to it in `@safe` code.
 
-This is where applying `@system`, `@trusted` and `@safe` to variables also becomes useful:
+Allowing `@trusted` and `@safe` to be applied to variables is useful when the programmer wants to relax the constraints, and applying `@system` is useful to tighten the constraints:
+
 ```D
-@system  extern int* x0; // May have unsafe value
-@safe    extern int* x1; // Assumed to always have safe value
+@trusted int* x = cast(int*) 0xD000; // Assumed to be a good address
+@safe    extern int* y0; // Assumed to always have safe value
+@system  extern int* y1; // May have unsafe value
+@system int* z = new int(20); // Starts out safe, but may be set to unsafe value in @trusted code
+
 enum Opt {a, b, c}
-@system  Opt option = Opt.a; // Not @safe to set it to e.g. `cast(Opt) 100`
-@trusted int* y = cast(int*) 0xD000; // Assumed to be a good address
+@system  Opt opt = Opt.a; // @trusted code relies on this being in range and not e.g. `cast(Opt) 100`
 ```
 
 ## Prior work
@@ -367,6 +370,7 @@ Note that while it may be desirable to require a `@trusted` annotation near init
 `@trusted` as a function annotation has its limitations:
 - it does not work for global or local variables since a `@trusted` lambda there would move the declaration to that function's scope.
 - it not only trusts initialization of the variable on the left-hand side of the `=`, but also the initialization expression on right-hand side.
+Using a `@trusted` function to return a variable by `ref` and assigning it does not count as initialization of that variable.
 - it disables the `scope`/`return scope` checks of `-dip1000`
 
 ```D
@@ -561,7 +565,6 @@ At the end of the preview period, there will also be a flag to revert it, `-reve
 ## Reference
 
 - [Safe Values](https://dlang.org/spec/function.html#safe-values)
-- [What type soundndess theorem do you really want to prove?](https://blog.sigplan.org/2019/10/17/what-type-soundness-theorem-do-you-really-want-to-prove/)
 - [The scope of unsafe](https://www.ralfj.de/blog/2016/01/09/the-scope-of-unsafe.html)
 - [safe unsafe meaning](https://doc.rust-lang.org/nightly/nomicon/safe-unsafe-meaning.html)
 

--- a/DIPs/DIP1035.md
+++ b/DIPs/DIP1035.md
@@ -1,18 +1,24 @@
 # `@system` Variables
 
-| Field           | Value                                                           |
-|-----------------|-----------------------------------------------------------------|
-| DIP:            | 1035                                                            |
-| Review Count:   | 1                                                               |
-| Author:         | Dennis Korpel dkorpel@gmail.com                                 |
-| Implementation: |                                                                 |
-| Status:         | Post-Community 1                                                |
+| Field           | Value                                                             |
+|-----------------|-------------------------------------------------------------------|
+| DIP:            | 1035                                                              |
+| Review Count:   | 1                                                                 |
+| Author:         | Dennis Korpel (dkorpel@gmail.com), Paul Backus                    |
+| Implementation: |                                                                   |
+| Status:         | Post-Community 1                                                  |
 
 ## Abstract
-When the `@system` attribute is attached to variables or fields, it means they cannot be written to in `@safe` functions.
-If the variable has an unsafe type (a type that has at least one pointer or `@system` field), it also cannot be read in `@safe` code.
-This allows more safe encapsulation of low-level unsafe code using `@trusted`, since currently `@trusted` code cannot assume anything about the integrity of data.
-It also fixes some existing issues with `@safe` code.
+
+The memory-safety of a program depends on the ability of the programmer and the language implementation to maintain the run-time invariants of the program's data.
+
+For built-in types, like arrays and pointers, the D compiler is aware of their run-time invariants, and can use compile-time checks to ensure they are maintained.
+For user-defined types, however, these checks are not always sufficient.
+In order to reliably maintain invariants beyond those that the compiler has hard-coded knowledge of, D programmers must resort to manual verification of `@safe` code and defensive run-time checks.
+
+This DIP proposes a new language feature, `@system` variables, to address this lack of expressiveness in D's memory-safety system.
+In `@safe` code, `@system` variables cannot be directly written to, and cannot have their values altered in uncontrolled ways via casting, overlapping, `void`-initialization, etc.
+As such, they can be relied upon to store data subject to arbitrary run-time invariants.
 
 ## Contents
 * [Background](#background)
@@ -27,134 +33,173 @@ It also fixes some existing issues with `@safe` code.
 
 ## Background
 
-A distinction can be made between syntactic types and semantic types.
-Syntactic types are the things the compiler understands: you cannot assign a `string` to an `int`, you cannot pass an integer array to a function that takes a `float` parameter, etc.
-While this helps catch bugs that assembly programmers encounter, it has limitations with regards to data abstraction and unsafe features.
-Often it is useful to make types that have additional constraints on the primitive types they consist of, or types that, from the outside, are safe and type-sound, but internally use unsafe operations that circumvent the type system.
-This can only work if the language in which such types are defined has the needed encapsulation capabilities.
+D's memory safety system distinguishes between *safe values*, which can be used freely in `@safe` code without causing undefined behavior, and *unsafe values*, which cannot.
+A type that has only safe values is a *safe type*; one that has both safe and unsafe values is an *unsafe type*.
+(For more detailed definitions of these and other related terms, refer to the *Function Safety* section of the D language spec.)
 
-For a detailed explanation about this concept, refer to the article "[What type soundndess theorem do you really want to prove?](https://blog.sigplan.org/2019/10/17/what-type-soundness-theorem-do-you-really-want-to-prove/)".
+The D compiler has built-in knowledge of which types are safe and which are not.
+In broad terms, pointers, arrays, and other reference types are unsafe; integers, characters, and floating-point numbers are safe; and the safety of aggregate types is determined by the safety of their members.
 
-D offers both low-level and high-level coding styles and is very well suited for writing safe types that internally use unsafe low-level primitives for performance.
-It only falls a bit short in its encapsulation capabilities, which this DIP tries to correct with `@system` variables and fields.
+A *run-time invariant* (or just "invariant") of a type is a rule that distinguishes between that type's safe and unsafe values.
+(N.B. "invariant" in this DIP is *not* referring to [invariant blocks in contract programming](https://dlang.org/spec/contracts.html#Invariants))
+The values that satisfy the invariant are safe; those that do not are unsafe.
+It follows that any type with a run-time invariant is unsafe, and that a safe type has no run-time invariants.
+
+To ensure that their invariants are not violated, the use of unsafe types is restricted in `@safe` code.
+Specifically:
+- They cannot be void-initialized.
+- They cannot be overlapped in a union.
+- A `T[]` cannot be cast to a `U[]` when U is an unsafe type.
+- Certain operators (pointer arithmetic, unsafe casts) are disallowed.
+
+In the proposed changes, both the list of unsafe types and the the list of restrictions will be extended.
 
 ## Rationale
 
-### Need for encapsulation of @trusted code
+While the system described above works well for built-in types and their invariants, it does not provide any way for the programmer to indicate that a user-defined type has additional invariants that the compiler may not be aware of.
+As a result, maintaining such invariants requires extra effort from the programmer.
+For unsafe types, the programmer may be required to manually verify that those invariants are maintained in `@safe` code.
+For safe types, the programmer may additionally be required to insert defensive run-time checks to ensure that those invariants are maintained.
 
-D supports writing memory-safe code using the `@safe` attribute, which disallows any operations that could corrupt memory.
-Among these restricted operations are void initialization and overlap of pointers:
+### Example: User-Defined Slice
 
 ```D
-void main() @safe {
-    int* a = void; // error: void initializers for pointers not allowed in safe functions
-    *a = 3; // who knows what happens?
-    union U {
-        uint asNum = 0x8035FDF0;
-        uint* asPtr;
+module intslice;
+
+struct IntSlice
+{
+    private int* ptr;
+    private size_t length;
+
+    @safe
+    this(int[] src)
+    {
+        ptr = &src[0];
+        length = src.length;
     }
-    U u;
-    *u.asPtr = 3; // error: field U.asPtr cannot access pointers in @safe code that overlap other fields
+
+    @trusted
+    ref int opIndex(size_t i)
+    {
+        assert(i < length);
+        return ptr[i];
+    }
 }
 ```
 
-However, sometimes using these operations is necessary for performance.
-Take, for example, a [tagged union](https://en.wikipedia.org/wiki/Tagged_union).
-To save on memory, it overlaps multiple fields of possibly different types, and then uses an integer tag to track which of the union's types is currently valid.
-As discussed above however, this is not allowed in `@safe` code when pointers, arrays, or classes are among the union members.
-One idea is to encapsulate a tagged union using a templated type and use `@trusted` getter methods that ensure the pointer members are only accessed when the tag ensures the underlying data is a valid pointer.
-[The sumtype](http://code.dlang.org/packages/sumtype) package does this.
+**Invariant:** The value of `length` must be equal to the length of the array pointed to by `ptr`.
 
-There is a loophole, however. By meddling with the `tag` field, memory can be corrupted in `@safe` code:
+First, observe that this code is memory-safe as-written (modulo [bugs](https://issues.dlang.org/show_bug.cgi?id=20941) in the compiler).
+There are only two functions that directly access `ptr` and `length`, and both of them correctly maintain the invariant.
+
+However, in order to *prove* that this code is memory-safe, it is not sufficient for the programmer to verify the correctness of its `@trusted` functions.
+Instead, *every* function that touches `ptr` and `length`, including the `@safe` constructor, must be manually checked.
+
+If `ptr` and `length` were `@system` variables, then all code that directly accesed them would have to be `@trusted`, and the programmer would not need to manually verify any `@safe` code in order to prove that `IntSlice`'s invariant is maintained.
+
+The same general pattern occurs with other user-defined types whose invariants involve the relationship between two or more variables, such as tagged unions and reference-counted smart pointers.
+
+### Example: Short String
 
 ```D
-/+ dub.sdl:
-dependency "sumtype" version="~>0.8.11"
-+/
-import sumtype;
-import std;
+module shortstring;
 
-void main() @safe {
-	immutable(int)* immutPtr = new int(10);
+struct ShortString
+{
+    private ubyte length;
+    private char[15] data;
 
- 	SumType!(immutable(int)*, int*) sum = immutPtr; // assign immutable pointer
+    @safe
+    this(const(char)[] src)
+    {
+        assert(src.length <= data.length);
 
-	__traits(getMember, sum, "tag") = 1; // ! ruin integrity of tagged union
+        length = cast(ubyte) src.length;
+        data[0 .. src.length] = src[];
+    }
 
-	sum.match!(
-		(ref immutable(int)* ptr) {}, // this one should be called
-		(ref int* ptr) {*ptr = 1000;}, // but we made it call this one
-	);
-
-	writeln(*immutPtr); // prints '1000'. The immutable pointer was mutated.
+    @trusted
+    const(char)[] opIndex() const
+    {
+        // should be ok to skip the bounds check here
+        return data.ptr[0 .. length];
+    }
 }
 ```
 
-It actually isn't currently possible to fix this because:
-- the tag having `private` visibility only encapsulates at the module level, while `@trusted` is applied at the function level, so it can still be violated by functions in the same module
-- even outside the module, `__traits(getMember, )` [bypasses `private`](https://github.com/dlang/dmd/pull/9585)
+**Invariant:** `length <= 15`
 
-A way of restricting access to the `tag` field from `@safe` code is needed to allow a `@safe` semantic type like this.
-The tagged union is just one example; there are many other situations where data should only be modified by code that "knows what it's doing".
-This is especially necessary for the recent push of `@safe` non-garbage collected data structures/system programming as evidenced by:
-- [Ownsership and borrowing in D](https://dlang.org/blog/2019/07/15/ownership-and-borrowing-in-d/)
-- [DIP1021](https://github.com/dlang/DIPs/blob/master/DIPs/accepted/DIP1021.md)
-- [my vision of D's future](https://dlang.org/blog/2019/10/15/my-vision-of-ds-future/)
+Once again, there is a constructor that establishes an invariant, and a member function that relies on the invariant to do its work.
+Unlike in the previous example, however, this code is *not* memory-safe as-written, though it may appear to be at first glance.
 
-Take reference counting, for example. As long as the reference count can be meddled from `@safe` code, freeing the memory cannot be `@trusted`, making `@safe` reference counting unsupported in D.
+To understand why, consider the following program, which uses `ShortString` to cause undefined behavior in `@safe` code:
 
-It is important to note that the concepts in this DIP have nothing to do with memory allocation or lifetimes.
-Even without freeing memory, restricting variable and field access from `@safe` code is still useful.
-Ensuring that `free` on manually managed memory can be encapsulated in a `@trusted` function is an important _application_ of this DIP, though.
-
-### Existing holes in `@safe`
-
-While constructing arbitrary pointers inside `@safe` code is not allowed, there is currently little defense around pointers initialized to an unsafe value outside any function:
 ```D
-@safe int* x = cast(int*) 0x7FFE_E800_0000; // compiles
+@safe
+void main()
+{
+    import shortstring;
+    import std.stdio;
 
-void main() @safe {
-    *x = 3; // memory corruption
+    ShortString oops = void;
+    writeln(oops[]);
 }
 ```
 
-This has partially been fixed in DMD [PR #10056](https://github.com/dlang/dmd/pull/10056)
+`void`-initializing a `ShortString` will very likely produce an instance that violates its invariant.
+Because `opIndex` relies on that invariant to skip the bounds check, this results in an out-of-bounds memory access rather than a safe, predictable crash.
+
+Why does the compiler allow a `ShortString` to be `void`-initialized in `@safe` code?
+Because, according to the rules in the language spec, a `struct` containing only `ubyte` and `char` data is a safe type, and therefore must not have any invariants.
+It follows that `@safe` code is free to initialize a `ShortString` to any value, including an unspecified one, without risking memory corruption.
+
+In order to make this code memory-safe, the programmer must include an additional bounds check in `opIndex`:
 
 ```D
-@safe:
-int* x = cast(int*) 0x7FFE_E800_0000; // error: cast from long to int* not allowed in safe code
-```
-
-It does not work when annotating the declaration as `@safe`, only when the variable is under a `@safe:` section.
-It is also easily circumvented:
-
-```D
-auto getPtr() @system {return cast(int*) 0x7FFE_E800_0000;}
-
-@safe:
-int* x = getPtr();
-
-void main() @safe {
-    int y = *x; // = 3; // memory corruption
+@safe
+const(char)[] opIndex() const
+{
+    return data[0 .. length];
 }
 ```
 
-Another issue is that, unlike pointers, the `bool` type is regarded `@safe` to overlap or void-initialize.
-The problem here is that the optimizer may assume it is always `0` or `1`, but the bool type can be any `ubyte` value in practice.
-By constructing a `bool` that is larger than 1 and indexing it in an array with compile-time length 2, memory can be corrupted since the range check is elided.
-See Issue #19968: [@safe code can create invalid bools resulting in memory corruption](https://issues.dlang.org/show_bug.cgi?id=19968)
+This solution is unsatisfying: the program must do redundant work at run-time to compensate for the language's lack of expressiveness, or give up on the guarantees of `@safe`.
+If `ShortString.length` could be marked as `@system`, this dilemma would not exist.
 
-The issue is marked fixed since DMD [PR #10055](https://github.com/dlang/dmd/pull/10055) was merged, which defensively inserts a bitwise 'and' operation (`b & 1`) when `bool` values are promoted to integers.
-This is not a complete solution however, since there are also other ways in which invalid booleans give undefined behavior: [void initializated bool can be both true and false](https://issues.dlang.org/show_bug.cgi?id=20148).
-This happens because negation of a `bool` is simply toggling the least significant bit with the xor operator (`b ^ 1`), which only works if all other bits are 0.
-This could, again, be fixed by inserting more `& 1` instructions, but it starts to defeat the purpose of a specialized `bool` primitive type when it cannot be guaranteed to be `0` or `1`---`bool` might as well be a wrapper around `ubyte` then.
+The same general pattern occurs with other user-defined types that attempt to impose invariants on types the compiler considers "safe", such as `enum` types used in `final switch` statements and integer "handles" used as array indices by external libraries.
 
-And even if one accepts this solution for booleans, the solution of ensuring validity on usage cannot work on pointers, since there is no simple operation that type checks a pointer at run time.
-A proper solution would be to maintain the invariant that only [safe values](https://dlang.org/spec/function.html#safe-values) of types can reach `@safe` functions.
+### Initial value of global variables
+
+Allowing fields of an aggregate to be marked `@system` helps the compiler *maintain* run-time invariants on user-defined types, but it is also important to ensure the variable was not constructed with an unsafe value to begin with.
+Constructing unsafe values in a `@safe` function is not allowed, and constructing them in `@system` or `@trusted` functions leaves the responsibility of memory safety up to the programmer.
+However, it is currently possible to construct unsafe global variables and use them in `@safe` functions.
+This not only applies to user-defined types, but also built-in types:
+```D
+int* x = cast(int*) 0xDEADBEEF;
+void main() @safe
+{
+    *x = 10;
+}
+```
+Since the initialization expression `cast(int*) 0xDEADBEEF` would not be allowed in a `@safe` function, the compiler should annotate variable `x` as possibly containing an unsafe value, so it may not be accessed in a `@safe` function.
+This is similar to [Taint-checking](https://en.wikipedia.org/wiki/Taint_checking).
+While in this case the 'may contain unsafe value' annotation is inferred and could remain internal to the compiler, there are cases where the programmer might want to help the compiler with this annotation:
+- The global variable is `extern`
+- The global variable is not of an unsafe type but still has run-time invariants
+- The initialization expression is `@system` but the programmer knows the resulting value is safe.
+
+This is where applying `@system`, `@trusted` and `@safe` to variables also becomes useful:
+```D
+@system  extern int* x0; // May have unsafe value
+@safe    extern int* x1; // Assumed to always have safe value
+enum Opt {a, b, c}
+@system  Opt option = Opt.a; // Not @safe to set it to e.g. `cast(Opt) 100`
+@trusted int* y = cast(int*) 0xD000; // Assumed to be a good address
+```
 
 ## Prior work
 
-The need for encapsulation of data/restricted access to data in order to achieve memory safety has been mentioned in several discussions:
+The need for encapsulation of data / restricted access to data in order to achieve memory safety has been mentioned in several discussions:
 
 - [#8035: tupleof ignoring private shouldn't be accepted in `@safe` code](https://github.com/dlang/dmd/pull/8035) (March 15, 2018)
 
@@ -171,6 +216,8 @@ The need for encapsulation of data/restricted access to data in order to achieve
 - [#7347: Fix issue 20495 (choose copies unused union member, which is unsafe)](https://github.com/dlang/phobos/pull/7347) (January 9, 2020)
 
 - [Re: @trusted attribute should be replaced with @trusted blocks](https://forum.dlang.org/post/mailman.773.1579207677.31109.digitalmars-d@puremagic.com) (January 16, 2020)
+
+- [Trust Me: An Exploration of @trusted Code in D - Steven Schveighoffer](https://youtu.be/O3TO52rXLug) (November 22, 2020)
 
 ### Other languages
 Many other languages either do not allow systems programming at all (e.g. Java, Python) or do not support language-enforced memory safety (e.g. C/C++).
@@ -219,8 +266,6 @@ void func(@system int x) // error: @system attribute for function parameter is n
 }
 template Temp(@system int x) {} // error: basic type expected, not @
 ```
-In short, anything that can be marked `private` can also be marked `@system`.
-Additionally, local variables can be marked `@system` (while they cannot be marked `private`).
 
 Any function attribute can be attached to a variable declaration, but they cannot be retrieved:
 ```D
@@ -228,31 +273,6 @@ Any function attribute can be attached to a variable declaration, but they canno
 pragma(msg, __traits(getFunctionAttributes, x)); // Error: first argument is not a function
 pragma(msg, __traits(getAttributes, x)); // tuple()
 ```
-
-### Unsafe types
-In the proposed changes, I use the term "unsafe types". An unsafe type is a type which has underlying bit-patterns that risk causing memory corruption in `@safe` code.
-A safe type, on the other hand, only exists with [safe values](https://dlang.org/spec/function.html#safe-values).
-
-The prime example of an unsafe type is a pointer, but any type that contains a pointer is also unsafe:
-- classes
-- arrays
-- associative arrays
-- a struct or union containing a pointer or one of the above types
-
-If one were allowed to arbitrarily change the bits of one of those types, one could construct a garbage pointer that can cause memory corruption in `@safe` code.
-By contrast, if one could arbitrarily change the bits of safe types such as `int` or `float`, it is not sufficient for memory corruption in `@safe` code.
-There is no equivalent to a dereference operator for an `int` or `float`---none of their operators touch other memory.
-One can use a garbage `int` as an array index and get unpredictable results, but when the index is out of bounds, a `RangeError` is thrown preventing memory corruption.
-
-Unsafe types can be used just fine in `@safe` code, for the most part. There are only a few restrictions to ensure their integrity:
-- they cannot be void-initialized
-- they cannot overlap in a union
-- a `T[]` cannot be cast to a `U[]` when `U` is an unsafe type.
-- certain operators (pointer arithmetic, unsafe casts) are disallowed
-
-In the proposed changes, both the list of unsafe types and the the list of restrictions are extended.
-
-It is worth reiterating that 'unsafe types' are not inferior to 'safe' types or bad for writing `@safe` code, they are simply types for which the integrity of the underlying bits is necessary for memory safety.
 
 ### Proposed changes
 
@@ -310,7 +330,7 @@ void main() @safe {
 ```
 
 Initialization of a `@system` variable or field is allowed in `@safe` code.
-This includes [static initializtion](https://dlang.org/spec/struct.html#static_struct_init), the automatically generated constructor, user-defined constructors, and the `.init` value of a type.
+This includes [static initialization](https://dlang.org/spec/struct.html#static_struct_init), the automatically generated constructor, user-defined constructors, and the `.init` value of a type.
 
 ```D
 @system int x;
@@ -397,7 +417,7 @@ void main() @safe {
 }
 ```
 
-Without this, implicit writes to `@system` variables are still possible.
+Without this rule, implicit writes to `@system` variables are still possible.
 
 **(2) _Reading_ from variables or fields marked `@system` is not allowed in `@safe` code if their type is unsafe**
 
@@ -475,325 +495,31 @@ Annotations with a scope (`@system {}`) or colon (`@system:`) affect variables j
 int y1; // @system
 ```
 
-**(4) `__traits(getFunctionAttributes)` may be called on variables and fields**
+**(4) A trait is added to inspect safety of types and variables**
 
-Currently it is possible to give function attributes to declarations that aren't functions.
-It is not possible, however, to inspect any of them.
-
-```D
-@system @nogc pure nothrow int x;
-pragma(msg, __traits(getFunctionAttributes, x)); // error: first argument is not a function
-pragma(msg, __traits(getAttributes, x)); // tuple()
-```
-
-Since attributes related to memory safety now have an effect on variables and fields, it becomes useful to inspect them.
-Therefore, the restriction on the `getFunctionAttributes` trait is lifted.
-
-The name "function attributes" is a bit unfortunate in this case, but this DIP does not aim to fix that.
-
-**(5) `bool` becomes an unsafe type**
-
-As explained in [the Rationale](#rationale) section, `bool` types either cause memory corruption when assumed to be always `0` or `1`, or might as well be `ubyte` types when almost every operation needs to truncate the value.
-By making `bool` an unsafe type, it can be both fast and `@safe` since all tricks to make invalid booleans are now disabled in `@safe` code.
-The cost is that existing code might break.
-Note that with the proposed rules a `bool` variable or field is only `@system` when the compiler cannot possibly prove that the initial value is `0` or `1`, which should be a rare occurrence.
-If there is code breakage, it will likely come from overlap or void initialization of booleans.
-```D
-immutable ubyte ub = 3;
-bool getValidBool()   pure @system {return true;}
-bool getInvalidBool() pure @system {return *(cast(bool*) &ub);}
-
-bool b0 = getValidBool();   // despite unsafe type with @system initialization expression, inferred as @safe
-bool b1 = getInvalidBool(); // inferred as system
-
-void main() @safe {
-    bool b = void; // no longer compiles
-}
-```
+Currently the safety of a function can be inspected using `__traits(getFunctionAttributes, x)`, but this does not work on variables or types.
+The new trait `__traits(isSafe, x)` returns a boolean:
+- If `x` is a function, variable or aggregate field, it will return whether it is marked `@safe`, `@trusted` or inferred `@safe`.
+- If `x` is a type, it will return whether it is a safe type, as described in [the background section](#background).
 
 ### Grammar changes
 
 There are no proposed grammar changes, since placing `@system` annotations is already allowed in the places where it's needed for this DIP.
 
-## Examples
-
-This section contains six examples that demonstrate use cases for the proposed changes.
-Each example *wrongly uses `@trusted`* under *current semantics*, followed by a `main` function demonstrating why.
-After this DIP is implemented, these will all become correct usages of `@trusted` and the `main` functions will fail to compile.
-
-### A tagged union
-This example shows how to safely overlap an unsafe type with another type.
-```D
-struct Var {
-    private union {
-        string asString = "var";
-        double asDouble;
-    }
-    enum Type : byte {
-        Str,
-        Num,
-    }
-    private @system Type type;
-
-    this(double x) @trusted {
-        this.type = Type.Num;
-        this.asDouble = x;
-    }
-
-    this(string s) @trusted {
-        this.type = Type.Str;
-        this.asString = s;
-    }
-
-    double getDouble() const @trusted {
-        return type == Type.Str ? asDouble : double.nan;
-    }
-
-    string getString() const @trusted {
-        return type == Type.Str ? asString : null;
-    }
-}
-
-import std;
-
-void main() @safe {
-    Var v = 1.0;
-    v.type = Var.Type.Str; // not allowed after this DIP
-    writeln(v.getString()); // memory corruption: the union messed up the string
-}
-```
-
-### Using uninitialized memory
-This simple stack data structure shows how to safely use an array with partially uninitialized memory.
-In this case, the stack data structure is using uninitialized stack memory, but the same idea applies to using uninitialized memory returned by `malloc`.
-Since destructors are still run on the entire array (also the uninitialized part), the struct has a template constraint that its element type must be plain old data.
-```D
-private struct Stack(T, int size = 32) if (__traits(isPOD, T)) {
-    private @system T[size] stack = void;
-    private @system int _top = 0;
-
-    T pop() @trusted {
-        if (empty) assert(0);
-        return stack[--_top];
-    }
-    void push(T x) {
-        if (full) assert(0);
-        // T might have a @system opAssign, so only make retrieval @trusted
-        delegate ref T() @trusted {return stack[_top++];}() = x;
-    }
-    bool empty() const {return _top == 0;}
-    bool full() const {return _top == size;}
-}
-
-auto getStack(T)() @trusted {
-    Stack!T result = void;
-    result._top = 0;
-    return result;
-}
-
-import std;
-
-void main() @safe {
-    auto stack = getStack!string();
-    stack._top += 1; // not allowed after this DIP
-    writeln(stack.pop); // memory corruption: garbage string is printed
-}
-```
-
-### A custom allocator
-This is a simple 'bump the pointer' allocator.
-```D
-@system private ubyte[4096] heap;
-@system private size_t heapIndex = 0;
-
-/// allocate an array of T
-/// never frees the memory
-T[] customAlloc(T)(int length) @trusted {
-    // round up heapIndex to multiple of T.alignof
-    heapIndex = (heapIndex + T.alignof-1) & ~(T.alignof-1);
-    auto result = cast(T[]) heap[heapIndex..heapIndex + T.sizeof*length];
-    heapIndex += heapIndex + T.sizeof*length;
-    return result;
-}
-
-import std;
-
-void main() @safe {
-    string[] strArr = customAlloc!string(3);
-    heapIndex = 0; // mess up allocator integrity! not allowed after this DIP.
-    int[] intArr = customAlloc!int(3);
-    intArr[] = -1; // overwrites string array
-    writeln(strArr[0]); // memory corruption: constructed pointer
-}
-```
-
-### A custom slice type
-Many arrays are small in length, and in certain situations one does not want 4 or 8 bytes to store the length when 2 suffices.
-A safe, small slice type is created below.
-It has room for extra fields, but `SmallSlice!T` is no larger than a regular `T[]`---it still fits in two CPU registers.
-```D
-struct SmallSlice(T) if (__traits(isPOD, T)) {
-    @system private T* ptr = null;
-    @system private ushort _length = 0;
-    ubyte[size_t.sizeof-2] extraSpace; // 2 on 32-bit, 6 on 64-bit
-
-    this(T[] slice) @trusted {
-        ptr = slice.ptr;
-        assert(slice.length <= ushort.max);
-        _length = cast(ushort) slice.length;
-    }
-
-    T opIndex(size_t i) @trusted {
-        return ptr[0.._length][i];
-    }
-}
-
-import std;
-
-void main() @safe {
-    int[4] arr = [10, 20, 30, 40];
-    auto slice = SmallSlice!int(arr[]);
-    __traits(getMember, slice, "_length") = 100; // change private member
-    writeln(slice[9]); // out of bounds memory access
-}
-```
-
-### A zero-terminated string
-String literals in D are zero-terminated, but that type information is lost as soon as one is assigned to a `const(char)*`, and using it becomes unsafe.
-With `@system` fields, a `@safe` zero-terminated string type can be made.
-```D
-struct Cstring {
-    @system const(char)* ptr = null;
-
-    this(const(char)* ptr) @system {
-        this.ptr = ptr;
-    }
-
-    size_t length() const @trusted {
-        import core.stdc.string: strlen;
-        return ptr ? strlen(ptr) : 0;
-    }
-}
-
-Cstring cStringLiteral(string s)() @trusted {
-    static immutable string tmp = s;
-    return Cstring(tmp.ptr); // static strings are guaranteed zero-terminated
-}
-
-import std;
-
-void main() @safe {
-    Cstring c = cStringLiteral!"hello";
-    c.ptr = new char('D'); // not allowed after this DIP
-    writeln(c.length); // memory corruption: strlen likely goes past the single 'D' character
-}
-```
-
-### An emulator or virtual machine
-In [an emulator](https://en.wikipedia.org/wiki/Emulator) or [virtual machine](https://en.wikipedia.org/wiki/Virtual_machine), it is often necessary to simulate another instruction set or byte code.
-A performance critical part of that is dispatching the instructions; based on an instruction's opcode (a small integer) a certain piece of code needs to be run that simulates that specific instruction.
-This is often achieved using a `switch`, [a computed `goto`](https://eli.thegreenplace.net/2012/07/12/computed-goto-for-efficient-dispatch-tables/), or an array of function pointers.
-Below is a simple example using the array method.
-The `.ptr` property is used to avoid bounds checks, which are relatively expensive in this case.
-We could have also used a `switch`, but currently that always has bounds checks in D (see [Issue #13169](https://issues.dlang.org/show_bug.cgi?id=13169)).
-
-In any case, it is important that the instruction opcodes do not exceed the size of the jump table, or memory gets corrupted.
-This is where `@system` variables come in, ensuring such invalid opcodes cannot reach `@safe` code.
-Notice how `VmInstruction` is an unsafe type that does not contain any pointer members, unlike the previous examples.
-Even though usually one can overlap a `ubyte` in a `union` in `@safe` code, with the wrapper struct the compiler knows that this is not memory-safe for `VmInstruction`.
-
-```D
-enum Opcode : ubyte {
-    decrement, increment, print,
-}
-
-struct VmInstruction {
-    @system Opcode opcode; // this need not be private, just a valid enum member
-    this(Opcode opcode) @safe {
-        assert(opcode <= Opcode.max, "opcode out of range");
-        this.opcode = opcode;
-    }
-}
-
-int gCounter;
-void decrementImpl() {gCounter++;};
-void incrementImpl() {gCounter--;};
-void printImpl() {import std; writeln(gCounter);};
-
-immutable void function()[3] jumpTable = [
-   &decrementImpl, &incrementImpl, &printImpl,
-];
-
-void execute(VmInstruction[] code) @trusted {
-    foreach(instruction; code) {
-        // indexing using .ptr to avoid bounds checks
-        jumpTable.ptr[instruction.opcode]();
-    }
-}
-
-void main() @safe {
-    VmInstruction[1] code;
-    code[0].opcode = cast(Opcode) 20;
-    execute(code);
-}
-```
-
-For an example of instruction dispatch in the wild, check out how [the GBAid emulator dispatches ARM instructions](https://github.com/DDoS/GBAiD/blob/9a61b4415f51db1087a70c929af926520bca328d/src/gbaid/gba/arm.d#L19).
-
 ## Alternatives
 
 ### Using `private`
 
-In March 2018, a restriction was added to `.tupleof` such that it could not bypass `private`.
-To avoid code breakge, the restriction is only in effect with the flag `-dip1000`.
-Walter Bright has stated the reason for this in [a comment](https://github.com/dlang/dmd/pull/8035#issuecomment-373627265):
-
-> @safe code should not be accessing private members in other modules, and using tupleof to "work around" that restriction is a giant hole in the @safe system.
-> Such code should be marked @trusted or @System.
-
-> A struct may present an @safe interface to users, but internally have private unsafe pointers.
-> tupleof allows any code to have access to those private members, and can mess up the invariants relied on by the struct.
-> Even int fields are not safe to access, as they may be used as an index to a pointer.
-
+It has been suggested before that bypassing `private` using e.g. `.tupleof` or `__traits(getMember)` should not be allowed in `@safe` code.
 While the need for giving a way of ensuring `struct` invariants in `@safe` code is in line with this DIP, the idea to use `private` for it is argued against.
 
-First of all, disallowing the bypassing of `private` in `@safe` code is not sufficient for ensuring struct invariants.
-As mentioned in the quote, sometimes invariants need to hold onto types that are not unsafe, such as `int`.
-When there are no pointer members, then private fields can still be indirectly written to using overlap in a union, void-initialization, or array casting.
+First of all, disallowing bypassing `private` in `@safe` code is not sufficient for ensuring run-time invariants on user-defined types.
+When an aggregate has no members with an unsafe type, the private fields can still be indirectly written to using overlap in a union, void-initialization or array casting.
 
-Secondly, it goes against the established 'zen' of `@safe` being the largest subset of the D language that ensures no memory corruption.
-[The specification says](https://dlang.org/spec/memory-safe-d.html#limitations):
+Second, `private` only acts on the module level, so a `@trusted` member function cannot assume that a struct's invariants are upheld unless all other `@safe` code in the module has been manually certified not to violate them.
+This undermines the ability of the programmer to easily distinguish code requiring manual verification from code that can be checked automatically, especially since certain member functions like constructors, destructors, and operator overloads *must* be defined in the same module as the data they operate on.
 
-> Memory safety does not imply that code is portable, uses only sound programming practices, is free of byte order dependencies, or other bugs. It is focussed only on eliminating memory corruption possibilities.
-
-There have been suggestions to disallow certain operations that are risky but not sufficient for memory corruption in `@safe` code, but [it has been stated](https://forum.dlang.org/post/qdl954$hbb$1@digitalmars.com) that `@safe` does not mean "no bugs":
-
-> Uninitialized non-pointers are @safe, because @safe refers to memory safety, not "no bugs".
-
-Accessing a `private` field is just as memory-safe as accessing a `public` field, so adding this restriction, while it potentially enables more `@trusted` code, is ultimately arbitrary.
-Defining `@system` variables is consistent with the existing practice of allowing functions to be marked `@system`.
-
-It also goes against the established [definition of trusted functions](https://dlang.org/spec/function.html#trusted-functions):
-
-> Trusted functions are guaranteed to not exhibit any undefined behavior if called by a safe function.
-> Furthermore, calls to trusted functions cannot lead to undefined behavior in @safe code that is executed afterwards.
-> It is the responsibility of the programmer to ensure that these guarantees are upheld.
-
-`private` only acts on the module level, so a `@trusted` member function cannot assume anything about member functions just because they are `private`.
-
-Finally, it would mean that circumventing visibility constraints using `__traits(getMember, ...)` must become `@system` or deprecated entirely, similarly to `.tupleof`.
-This would break all (`@safe`) code that uses this feature, and reintroduces the problems of [Issue #15371](https://issues.dlang.org/show_bug.cgi?id=15371).
-All things considered, making `private` work with `@trusted` appears to be a bigger hassle than introducing checks for `@system` variables and fields.
-
-### Not making bool an unsafe type
-It has been proposed that `void` initialization should be disallowed entirely in `@safe` code, which would partially solve the problem of invalid `bool` values in `@safe` code.
-
-See the comment on [Issue #20148 - void initializated bool can be both true and false](https://issues.dlang.org/show_bug.cgi?id=20148):
-> So instead of closing the obvious hole of @safe functions using void initialization we're just poking at symptoms here and there?
-
-This would still leave vulnerable each `bool` in a union or a `bool[]` that was typecast from a `ubyte[]`.
-Truncating booleans in only those situations is a possible compromise, though treating the `bool` type as unsafe is still seen as an improvement.
-The proposal to disallow void initialization in `@safe` code still has merits other than preventing invalid booleans, and treating booleans as unsafe types has its merits even without the ability to void-initialize them.
+Finally, disallowing bypassing visibility with `__traits(getMember, ...)` or `.tupleof` would break `@safe` code that relied on this, and [issue 15371](https://issues.dlang.org/show_bug.cgi?id=15371) explicitly requested this behavior.
 
 ## Breaking Changes and Deprecations
 
@@ -814,7 +540,7 @@ void main() @safe {
 }
 ```
 
-Misconstructed pointers and `bool` variables can also be inferred `@system` under the new rules.
+Misconstructed pointers can be inferred `@system` under the new rules.
 ```D
 struct S {
     int* a = cast(int*) 0x8035FDF0;
@@ -823,18 +549,18 @@ struct S {
 void main() @safe {
     S s;
     *s.a = 0; // this gives an error now
-    int[1] intArr = [-1];
-    auto boolArr = cast(bool[]) intArr; // this too
 }
 ```
 
 Whenever this happens, there is a risk of memory corruption, so a compiler error would be in its place.
-In any case, a two-year deprecation period is proposed where instead of raising an error, a deprecation message is given whenever the new memory safety rules are broken.
-A preview flag `-preview=systemVariables` can also be added that immediately raises errors for violations while leaving other deprecation messages as warnings.
+
+Still, a two-year deprecation period is proposed where instead of raising an error, a deprecation message is given whenever the new memory safety rules are broken.
+A preview flag `-preview=systemVariables` can additionally be added that immediately raises errors for violations while leaving other deprecation messages as warnings.
 At the end of the preview period, there will also be a flag to revert it, `-revert=systemVariables`, so that users can choose to keep the old behavior for a little longer.
 
 ## Reference
 
+- [Safe Values](https://dlang.org/spec/function.html#safe-values)
 - [What type soundndess theorem do you really want to prove?](https://blog.sigplan.org/2019/10/17/what-type-soundness-theorem-do-you-really-want-to-prove/)
 - [The scope of unsafe](https://www.ralfj.de/blog/2016/01/09/the-scope-of-unsafe.html)
 - [safe unsafe meaning](https://doc.rust-lang.org/nightly/nomicon/safe-unsafe-meaning.html)
@@ -853,7 +579,7 @@ Licensed under Creative Commons Zero 1.0
 
 [Feedback](https://forum.dlang.org/post/teoiwvqqpfqcyfnduvhc@forum.dlang.org)
 
-In the Feedback Thread, most of the feedback was related to details such as terminology, whether to use `assert(x)` in the examples, etc. 
+In the Feedback Thread, most of the feedback was related to details such as terminology, whether to use `assert(x)` in the examples, etc.
 
 The one structural piece of criticism was that making initialization of `@system` variables safe is unsound, to wit, "Memory safety cannot depend on the correctness of a `@safe` constructor." The DIP author replied that this boils down to "@trusted assumptions about @safe code", on which there is no consensus, and he has yet to determine a satisfactory design.
 


### PR DESCRIPTION
Paul Backus generously sent me a proposed revision to the DIP cutting it down and explaining things more naturally.
Andrei Alexandrescu suggested making a comparison with [Taint checking](https://en.wikipedia.org/wiki/Taint_checking), I have not written that yet. I also still need to decide whether to keep "(5) `bool` becomes an unsafe type".