### PR TITLE
DIP1038 - Last-minute revisions

### DIFF
--- a/DIPs/DIP1038.md
+++ b/DIPs/DIP1038.md
@@ -367,15 +367,15 @@ Making `@nodiscard` meaningful only as a type attribute, without the
 syntax-level check, would leave D programmers with only choice (2). As a
 result, while programmers who did choose to use `@nodiscard` might be better
 off, there would be fewer of them than there would be if choice (1) were also
-available.
+available. On balance, the author belives that the design proposed by this DIP
+is likely to be more useful to more D programmers in practice than one which
+excludes the syntax-level check.
 
-On balance, the author belives that the design proposed by this DIP is likely
-to be more useful to more D programmers in practice than one which excludes the
-syntax-level check. The experience of other languages appears to support this
-hypothesis: in C and C++, the syntax-level check was considered useful enough
-to be worth inlcuding on its own; and in Rust, the syntax-level check was
-considered useful enough to be worth including (via [RFC 1940][Rfc1940]) even
-with the more-rigorous type-level check already in the language.
+The experience of other languages appears to support this hypothesis. In C and
+C++, the syntax-level check was considered useful enough to be worth inlcuding
+on its own. In Rust, the syntax-level check was considered useful enough to be
+worth including (via [RFC 1940][Rfc1940]) even with the more-rigorous
+type-level check already in the language.
 
 Nevertheless, if the language maintainers are not prepared to accept the
 syntax-level check at this time, accepting `@nodiscard` as an attribute only

--- a/DIPs/DIP1038.md
+++ b/DIPs/DIP1038.md
@@ -367,9 +367,20 @@ available.
 
 On balance, the author belives that the design proposed by this DIP is likely
 to be more useful to more D programmers in practice than one which excludes the
-syntax-level check. However, accepting `@nodiscard` only as a type attribute
-with a type-level check would be a reasonable compromise if the syntax-level
-check is deemed inadequate by the language maintainers.
+syntax-level check. The experience of other languages appears to support this
+hypothesis: in C and C++, the syntax-level check was considered useful enough
+to be worth inlcuding on its own; and in Rust, the syntax-level check was
+considered useful enough to be worth including (via [RFC 1940][Rfc1940]) even
+with the more-rigorous type-level check already in the language.
+
+Nevertheless, if the language maintainers are not prepared to accept the
+syntax-level check at this time, accepting `@nodiscard` as an attribute only
+for types, with a type-level check, is a compromise that would preserve many of
+the benefits of this DIP's proposal. In this case, to allow for the possibility
+of future expansion, annotating a function with `@nodiscard` should result in a
+compile-time error.
+
+[Rfc1940]: https://rust-lang.github.io/rfcs/1940-must-use-functions.html
 
 ## Breaking Changes and Deprecations
 

--- a/DIPs/DIP1038.md
+++ b/DIPs/DIP1038.md
@@ -116,11 +116,12 @@ worth the potential for breakage.
 
 ### In D
 
-The D compiler already warns about discarding the value of an expression with
-no side effects, including a call to a strongly-`pure` and `nothrow` function.
-An attribute that would allow the programmer to mark specific functions or
-types as non-discardable has been proposed several times on the D issue tracker
-and forums; see the [Reference](#reference) section below for details.
+The D compiler already warns about discarding the value of an expression if it
+has no side effects, including the case where the expression is a call to a
+strongly-`pure` and `nothrow` function. An attribute that would allow the
+programmer to extend this warning by marking specific functions or types as
+non-discardable has been proposed several times on the D issue tracker and
+forums; see the [Reference](#reference) section below for details.
 
 ### In Other Languages
 

--- a/DIPs/DIP1038.md
+++ b/DIPs/DIP1038.md
@@ -135,7 +135,7 @@ forums; see the [Reference](#reference) section below for details.
 [GccWarnUnusedResult]: https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#Common-Function-Attributes
 [ClangWarnUnusedResult]: https://clang.llvm.org/docs/AttributeReference.html#nodiscard-warn-unused-result
 
-#### Cross-Language Comparison Table
+### Cross-Language Comparison Table
 
 |Language      |Attribute           |Applies to         |Analysis                   |Diagnostic
 |--------------|--------------------|-------------------|---------------------------|----------

--- a/DIPs/DIP1038.md
+++ b/DIPs/DIP1038.md
@@ -380,7 +380,7 @@ type-level check already in the language.
 Nevertheless, if the language maintainers are not prepared to accept the
 syntax-level check at this time, accepting `@nodiscard` as an attribute only
 for types, with a type-level check, is a compromise that would preserve many of
-the benefits of this DIP's proposal. In this case, to allow for the possibility
+the benefits of this DIP's proposal. In that case, to allow for the possibility
 of future expansion, annotating a function with `@nodiscard` should result in a
 compile-time error.
 

--- a/DIPs/DIP1038.md
+++ b/DIPs/DIP1038.md
@@ -223,6 +223,10 @@ those described above. In particular:
   `@nodiscard` does not implicitly propagate from outer scopes to inner ones).
 * `@nodiscard` has no semantic effect on declarations other than aggregate and
   function declarations.
+* `@nodiscard` has no effect on declarations other than the ones it is
+  explicitly aplied to. In particular, a `@nodiscard` annotation on a class is
+  not inherited by classes that inherit from it, and a `@nodiscard` annotation
+  on a virtual function is not inherited by functions that override it.
 
 ### Design Goals and Possible Alternatives
 

--- a/DIPs/DIP1038.md
+++ b/DIPs/DIP1038.md
@@ -135,6 +135,18 @@ forums; see the [Reference](#reference) section below for details.
 [GccWarnUnusedResult]: https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#Common-Function-Attributes
 [ClangWarnUnusedResult]: https://clang.llvm.org/docs/AttributeReference.html#nodiscard-warn-unused-result
 
+#### Cross-Language Comparison Table
+
+|Language      |Attribute           |Applies to         |Analysis                   |Diagnostic
+|--------------|--------------------|-------------------|---------------------------|----------
+|C++17         |`[[nodiscard]]`     |Types and functions|Syntax-level               |Warning
+|Rust          |`#[must_use]`       |Types and functions|Type-level and syntax-level|Warning
+|C (GCC, Clang)|`warn_unused_result`|Functions          |Syntax-level               |Warning
+|D (DIP 1038)  |`@nodiscard`        |Types and functions|Type-level and syntax-level|Error
+
+The distinction between syntax-level and type-level analysis is discussed in
+the [Description](#description) section below.
+
 ## Description
 
 `@nodiscard` is a compiler-recognized user-defined attribute declared in the D


### PR DESCRIPTION
Main change is a more detailed comparison of DIP 1038's `@nodiscard` with similar features in other languages.