### PR TITLE
DIP 1038 Post-formal-assessment revisions

### DIFF
--- a/DIPs/DIP1038.md
+++ b/DIPs/DIP1038.md
@@ -246,8 +246,8 @@ There are two possibilities:
    accidentally discarded in some cases, without an explicit cast or type
    conversion.
 
-Option (1) sacrificies spec and implementation simplicity to maintain rigor;
-option (2) sacrifices rigor to maintain simplicity.
+Option (1) sacrificies specification simplicity and implementation simplicity
+to maintain rigor; option (2) sacrifices rigor to maintain simplicity.
 
 Rather than make either sacrifice, this DIP proposes a design that allows both
 rigor and simplicity to be maintained, and reserves the possibility for a

--- a/DIPs/DIP1038.md
+++ b/DIPs/DIP1038.md
@@ -11,9 +11,9 @@
 ## Abstract
 
 This DIP proposes a new attribute, `@mustUse`, that allows the programmer to
-make ignoring a function's return value into a compile-time error. It can be
-used to implement alternative error-handling mechanisms for code that cannot
-use exceptions, including `@nogc` and BetterC code.
+make ignoring an expression's value into a compile-time error. It can be used
+to implement alternative error-handling mechanisms for code that cannot use
+exceptions, including `@nogc` and BetterC code.
 
 ## Contents
 * [Rationale](#rationale)

--- a/DIPs/DIP1038.md
+++ b/DIPs/DIP1038.md
@@ -10,10 +10,11 @@
 
 ## Abstract
 
-This DIP proposes a new attribute, `@mustUse`, that allows the programmer to
-make ignoring an expression's value into a compile-time error. It can be used
-to implement alternative error-handling mechanisms for code that cannot use
-exceptions, including `@nogc` and BetterC code.
+This DIP proposes a new attribute, `@mustUse`, which can be applied to a
+`struct` or `union` type to make ignoring an expression of that type into a
+compile-time error. It can be used to implement alternative error-handling
+mechanisms for code that cannot use exceptions, including `@nogc` and BetterC
+code.
 
 ## Contents
 * [Rationale](#rationale)

--- a/DIPs/DIP1038.md
+++ b/DIPs/DIP1038.md
@@ -1,4 +1,4 @@
-# @nodiscard
+# @mustUse
 
 | Field           | Value                                                           |
 |-----------------|-----------------------------------------------------------------|
@@ -10,7 +10,7 @@
 
 ## Abstract
 
-This DIP proposes a new attribute, `@nodiscard`, that allows the programmer to
+This DIP proposes a new attribute, `@mustUse`, that allows the programmer to
 make ignoring a function's return value into a compile-time error. It can be
 used to implement alternative error-handling mechanisms for code that cannot
 use exceptions, and to prevent bugs when interfacing with external functions
@@ -44,7 +44,7 @@ Since D is intended to be a systems language suitable for writing low-level,
 high-performance code with seamless C and C++ interoperability, its feature set
 should support reliable error handling in all of these use-cases.
 
-`@nodiscard` helps D achieve this goal by enabling reliable error handling both
+`@mustUse` helps D achieve this goal by enabling reliable error handling both
 for functions that use raw error codes (most commonly, `extern(C)` functions)
 and for functions that use algebraic "result" types to signal failure to their
 callers.
@@ -56,13 +56,13 @@ Panteleev][SuccessType], is for a function to return an error code wrapped in a
 `struct` that `assert`s (or `throw`s) in its destructor at run time if it has
 not been used (where "using" means calling a particular method). While this
 addresses some of the use-cases above, it has several shortcomings compared to
-`@nodiscard`:
+`@mustUse`:
 
 * it reports ignored errors at run time rather than compile time;
 * it cannot be used directly with functions written in other languages;
 * it requires additional syntax in both the callee and its callers to wrap and unwrap the error code.
 
-By contrast, `@nodiscard` can be used without caveats to provide compile-time
+By contrast, `@mustUse` can be used without caveats to provide compile-time
 protection against ignored errors in all of the use-cases listed above.
 
 Another alternative is for a function to return error information via an `out`
@@ -81,7 +81,7 @@ include:
   have a specific signature;
 * the function is an operator overload.
 
-By contrast, `@nodiscard` can be used with any function because all functions
+By contrast, `@mustUse` can be used with any function because all functions
 have a return type.
 
 ### Functions without specified side effects
@@ -101,14 +101,14 @@ side effects without risking breakage if and when those implementation details
 change.
 
 Though ignoring the return values of these functions is unlikely to result in
-disaster, it is still a probable programming mistake which `@nodiscard` could
+disaster, it is still a probable programming mistake which `@mustUse` could
 help guard against.
 
-This DIP does not recommend adding `@nodiscard` to any existing functions in
+This DIP does not recommend adding `@mustUse` to any existing functions in
 Phobos or the D runtime since doing so would constitute a breaking API change.
-However, authors of new code would still benefit from having `@nodiscard` in
+However, authors of new code would still benefit from having `@mustUse` in
 the language and existing projects (including Phobos and the D runtime) could
-adopt `@nodiscard` on a case-by-case basis if the benefit were judged to be
+adopt `@mustUse` on a case-by-case basis if the benefit were judged to be
 worth the potential for breakage.
 
 ## Prior Work
@@ -141,14 +141,14 @@ forums; see the [Reference](#reference) section below for details.
 |C++17         |`[[nodiscard]]`     |Types and functions|Syntax-level               |Warning
 |Rust          |`#[must_use]`       |Types and functions|Type-level and syntax-level|Warning
 |C (GCC, Clang)|`warn_unused_result`|Functions          |Syntax-level               |Warning
-|D (DIP 1038)  |`@nodiscard`        |Types and functions|Type-level and syntax-level|Error
+|D (DIP 1038)  |`@mustUse`        |Types and functions|Type-level and syntax-level|Error
 
 The distinction between syntax-level and type-level analysis is discussed in
 the [Description](#description) section below.
 
 ## Description
 
-`@nodiscard` is a compiler-recognized user-defined attribute declared in the D
+`@mustUse` is a compiler-recognized user-defined attribute declared in the D
 runtime module `core.attribute`. It takes no arguments.
 
 An expression is considered to be discarded if and only if either of the
@@ -162,13 +162,13 @@ It is a compile-time error to discard an expression if either of the following
 is true:
 
 * it is a call to a function whose declaration is annotated with
-  `@nodiscard`, or
+  `@mustUse`, or
 * it is not an assignment expression, and its type is an aggregate (a `struct`,
   `union`, `class`, or `interface`) whose declaration is annotated with
-  `@nodiscard`.
+  `@mustUse`.
 
 Note that the former is a syntax-level check, while the latter is a type-level
-check. This means that the *value* returned from a `@nodiscard`-annotated
+check. This means that the *value* returned from a `@mustUse`-annotated
 function may be discarded as long as the function call itself is
 enclosed in some other expression. For example:
 
@@ -176,8 +176,8 @@ enclosed in some other expression. For example:
 // un-annotated type
 struct Result { int n; }
 
-// @nodiscard-annotated function
-@nodiscard Result func() { return Result(0); }
+// @mustUse-annotated function
+@mustUse Result func() { return Result(0); }
 
 void main()
 {
@@ -188,12 +188,12 @@ void main()
 }
 ```
 
-By contrast, a value of a `@nodiscard`-annotated type will always cause an
+By contrast, a value of a `@mustUse`-annotated type will always cause an
 error if it is discarded, regardless of the expression that discards it:
 
 ```d
-// @nodiscard-annotated type
-@nodiscard struct Result { int n; }
+// @mustUse-annotated type
+@mustUse struct Result { int n; }
 
 // un-annotated function
 Result func() { return Result(0); }
@@ -207,29 +207,29 @@ void main()
 }
 ```
 
-In all cases, an error resulting from `@nodiscard` can be suppressed by
+In all cases, an error resulting from `@mustUse` can be suppressed by
 prepending `cast(void)` to the offending expression, since a *CastExpression*
 is not a function call and `void` is not an aggregate type annotated with
-`@nodiscard`.
+`@mustUse`.
 
-Using `@nodiscard` has no effects on the semantics of a program other than
+Using `@mustUse` has no effects on the semantics of a program other than
 those described above. In particular:
 
-* `@nodiscard` is not part of the type of any symbol to which it is applied to and does
+* `@mustUse` is not part of the type of any symbol to which it is applied to and does
   not participate in name mangling.
-* A `@nodiscard` annotation on a function or aggregate declaration does not
+* A `@mustUse` annotation on a function or aggregate declaration does not
   apply to declarations inside that function or aggregate's body (that is,
-  `@nodiscard` does not implicitly propagate from outer scopes to inner ones).
-* `@nodiscard` has no semantic effect on declarations other than aggregate and
+  `@mustUse` does not implicitly propagate from outer scopes to inner ones).
+* `@mustUse` has no semantic effect on declarations other than aggregate and
   function declarations.
-* `@nodiscard` has no effect on declarations other than the ones to which it is
-  explicitly applied. In particular, a `@nodiscard` annotation on a class is
-  not inherited by classes that inherit from it, and a `@nodiscard` annotation
+* `@mustUse` has no effect on declarations other than the ones to which it is
+  explicitly applied. In particular, a `@mustUse` annotation on a class is
+  not inherited by classes that inherit from it, and a `@mustUse` annotation
   on a virtual function is not inherited by functions that override it.
 
 ### Design Goals and Possible Alternatives
 
-The design for `@nodiscard` described above was chosen to achieve the best
+The design for `@mustUse` described above was chosen to achieve the best
 possible balance among the following goals:
 
 1. **Simplicity of specification.** A language feature that is difficult to
@@ -253,12 +253,12 @@ are discussed below.
 #### Dataflow analysis
 
 As noted above, the design presented in this DIP allows "false negatives":
-expressions in which the return value of a `@nodiscard`-annotated function is
+expressions in which the return value of a `@mustUse`-annotated function is
 discarded without triggering a compile-time error.
 
 One way to avoid false negatives would be to have the compiler perform dataflow
 analysis to determine which expressions could potentially evaluate to the
-return value of a `@nodiscard`-annotated function, and issue an error if any of
+return value of a `@mustUse`-annotated function, and issue an error if any of
 those expressions were discarded.
 
 Whole-program dataflow analysis would completely eliminate false negatives, but
@@ -268,12 +268,12 @@ the other hand, would be more feasible to implement, but would still allow
 false negatives in some cases. For example:
 
 ```d
-@nodiscard int dontIgnoreMe() { return 42; }
+@mustUse int dontIgnoreMe() { return 42; }
 int identity(int n) { return n; }
 
 void main()
 {
-    // no error: identity is not annotated with @nodiscard
+    // no error: identity is not annotated with @mustUse
     identity(dontIgnoreMe());
 }
 ```
@@ -283,9 +283,9 @@ design would be far greater than that of the design proposed by this DIP. If
 written with sufficient detail to fully describe the implementation's behavior,
 the specification's complexity would be significantly greater as well.
 
-#### `nodiscard` type qualifier
+#### `mustUse` type qualifier
 
-Another way to avoid false negatives would be to make `nodiscard` a type
+Another way to avoid false negatives would be to make `mustUse` a type
 qualifier rather than an attribute. This would allow the type-level check,
 which does not suffer from false negatives, to be applied to return values of
 *any* type, not just user-defined aggregate types, and eliminate the need for
@@ -293,36 +293,36 @@ the syntax-level check.
 
 Because type qualifiers are an established concept in the language
 specification with an existing implementation, the specification and
-implementation complexity of a `nodiscard` type qualifier would likely be
+implementation complexity of a `mustUse` type qualifier would likely be
 relatively low.
 
-Unfortunately, making `nodiscard` a type qualifier would introduce significant
+Unfortunately, making `mustUse` a type qualifier would introduce significant
 friction in the form of "false positives": expressions that do not discard a
-`nodiscard`-qualified value, but are diagnosed by the compiler as though they
+`mustUse`-qualified value, but are diagnosed by the compiler as though they
 do. For example:
 
 ```d
-nodiscard(int) dontIgnoreMe() { return 42; }
+mustUse(int) dontIgnoreMe() { return 42; }
 int identity(int n) { return n; }
 
 void main()
 {
-    // error: cannot pass nodiscard(int) argument to int parameter
+    // error: cannot pass mustUse(int) argument to int parameter
     auto result = identity(dontIgnoreMe());
 }
 ```
 
 This friction would be particularly severe for programmers attempting to make
-newly-written D code that uses `nodiscard` work together with existing D code
-that does not—in other words, for `nodiscard`'s earliest adopters. The most
+newly-written D code that uses `mustUse` work together with existing D code
+that does not—in other words, for `mustUse`'s earliest adopters. The most
 likely result would be a language feature that, while theoretically more sound,
 would provide less utility to D programmers in practice than the design
 proposed by this DIP.
 
-#### Type-only `@nodiscard` attribute
+#### Type-only `@mustUse` attribute
 
 Perhaps the easiest way to avoid false negatives would be to simply drop the
-syntax-level check and recognize the `@nodiscard` attribute only when applied
+syntax-level check and recognize the `@mustUse` attribute only when applied
 to an aggregate type. The resulting design would be strictly less complex in
 terms of both specification and implementation than the one this DIP proposes,
 and would not introduce any risk of false positives.
@@ -345,12 +345,12 @@ void noGood()
 }
 ```
 
-Suppose that we would like to use `@nodiscard` to ensure that the return value
-of `dontIgnoreMe` is not discarded. With the design for `@nodiscard` proposed
+Suppose that we would like to use `@mustUse` to ensure that the return value
+of `dontIgnoreMe` is not discarded. With the design for `@mustUse` proposed
 by this DIP, there are two ways we can go about it:
 
-1. We can annotate `dontIgnoreMe` with `@nodiscard`.
-2. We can change the return type of `dontIgnoreMe` to a `@nodiscard`-annotated
+1. We can annotate `dontIgnoreMe` with `@mustUse`.
+2. We can change the return type of `dontIgnoreMe` to a `@mustUse`-annotated
    type.
 
 If we choose (1), the only other change we need to make is to update the call
@@ -359,12 +359,12 @@ already correct and can be left alone.
 
 If we choose (2), however, we must update *every* call site of `dontIgnoreMe`,
 whether it discards the return value or not. If our program were larger, the
-prospect of doing so might discourage us from using `@nodiscard` in the first
+prospect of doing so might discourage us from using `@mustUse` in the first
 place.
 
-Making `@nodiscard` meaningful only as a type attribute, without the
+Making `@mustUse` meaningful only as a type attribute, without the
 syntax-level check, would leave D programmers with only choice (2). As a
-result, while programmers who did choose to use `@nodiscard` might be better
+result, while programmers who did choose to use `@mustUse` might be better
 off, there would be fewer of them than there would be if choice (1) were also
 available. On balance, the author believes that the design proposed by this DIP
 is likely to be more useful to more D programmers in practice than one which
@@ -377,10 +377,10 @@ worth including (via [RFC 1940][Rfc1940]) even with the more rigorous
 type-level check already in the language.
 
 Nevertheless, if the language maintainers are not prepared to accept the
-syntax-level check at this time, accepting `@nodiscard` as an attribute only
+syntax-level check at this time, accepting `@mustUse` as an attribute only
 for types, with a type-level check, is a compromise that would preserve many of
 the benefits of this DIP's proposal. In that case, to allow for the possibility
-of future expansion, annotating a function with `@nodiscard` should result in a
+of future expansion, annotating a function with `@mustUse` should result in a
 compile-time error.
 
 [Rfc1940]: https://rust-lang.github.io/rfcs/1940-must-use-functions.html

--- a/DIPs/DIP1038.md
+++ b/DIPs/DIP1038.md
@@ -13,8 +13,7 @@
 This DIP proposes a new attribute, `@mustUse`, that allows the programmer to
 make ignoring a function's return value into a compile-time error. It can be
 used to implement alternative error-handling mechanisms for code that cannot
-use exceptions, and to prevent bugs when interfacing with external functions
-that report errors via their return values.
+use exceptions, including `@nogc` and BetterC code.
 
 ## Contents
 * [Rationale](#rationale)
@@ -45,44 +44,41 @@ high-performance code with seamless C and C++ interoperability, its feature set
 should support reliable error handling in all of these use-cases.
 
 `@mustUse` helps D achieve this goal by enabling reliable error handling both
-for functions that use raw error codes (most commonly, `extern(C)` functions)
-and for functions that use algebraic "result" types to signal failure to their
-callers.
+for functions that use error codes and for functions that use algebraic
+"result" types to signal failure to their callers.
 
 #### Alternatives
 
 One possible alternative to exceptions, [proposed by Vladimir
 Panteleev][SuccessType], is for a function to return an error code wrapped in a
 `struct` that `assert`s (or `throw`s) in its destructor at run time if it has
-not been used (where "using" means calling a particular method). While this
-addresses some of the use-cases above, it has several shortcomings compared to
-`@mustUse`:
+not been used (where "using" means calling a method to retrieve the wrapped
+value).
 
-* it reports ignored errors at run time rather than compile time;
-* it cannot be used directly with functions written in other languages;
-* it requires additional syntax in both the callee and its callers to wrap and unwrap the error code.
-
-By contrast, `@mustUse` can be used without caveats to provide compile-time
-protection against ignored errors in all of the use-cases listed above.
+While this addresses some of the use-cases above, it has one major shortcoming
+compared to `@mustUse`: it reports ignored errors at run time rather than
+compile time.
 
 Another alternative is for a function to return error information via an `out`
 parameter. Since a call to the function will not compile with a missing
 argument, the calling code is forced at compile time to visibly acknowledge the
 possibility of an error.
 
-Unfortunately, using `out` parameters for error handling is not a
-generally applicable solution because the programmer is not always free to
-change a function's signature to include an `out` parameter. Reasons for this
+Unfortunately, using `out` parameters for error handling is not a generally
+applicable solution because the programmer is not always free to change a
+function's argument list to include an `out` parameter. Reasons for this
 include:
 
-* the function's signature is part of an established public API, and changing
-  it would break other code;
+* the function's argument list is part of an established public API, and
+  changing it would break other code;
 * the function is used as a callback by another function that requires it to
-  have a specific signature;
+  accept a specific list of arguments;
 * the function is an operator overload.
 
-By contrast, `@mustUse` can be used with any function because all functions
-have a return type.
+By contrast, `@mustUse` requires only the freedom to change a function's return
+type, and this change can in many cases be made backwards-compatible by using
+`alias this` to allow implicit conversion of the new return type to the old
+one.
 
 ### Functions without specified side effects
 
@@ -104,12 +100,12 @@ Though ignoring the return values of these functions is unlikely to result in
 disaster, it is still a probable programming mistake which `@mustUse` could
 help guard against.
 
-This DIP does not recommend adding `@mustUse` to any existing functions in
-Phobos or the D runtime since doing so would constitute a breaking API change.
-However, authors of new code would still benefit from having `@mustUse` in
-the language and existing projects (including Phobos and the D runtime) could
-adopt `@mustUse` on a case-by-case basis if the benefit were judged to be
-worth the potential for breakage.
+This DIP does not recommend changing the return types of any existing functions
+in Phobos or the D runtime to `@mustUse` types, since doing so would constitute
+a breaking API change. However, authors of new code would still benefit from
+having `@mustUse` in the language and existing projects (including Phobos and
+the D runtime) could adopt `@mustUse` on a case-by-case basis if the benefit
+were judged to be worth the potential for breakage.
 
 ## Prior Work
 
@@ -136,17 +132,16 @@ forums; see the [Reference](#reference) section below for details.
 
 ### Cross-Language Comparison Table
 
-|Language      |Attribute           |Applies to         |Analysis                   |Diagnostic
-|--------------|--------------------|-------------------|---------------------------|----------
-|C++17         |`[[nodiscard]]`     |Types and functions|Syntax-level               |Warning
-|Rust          |`#[must_use]`       |Types and functions|Type-level and syntax-level|Warning
-|C (GCC, Clang)|`warn_unused_result`|Functions          |Syntax-level               |Warning
-|D (DIP 1038)  |`@mustUse`        |Types and functions|Type-level and syntax-level|Error
-
-The distinction between syntax-level and type-level analysis is discussed in
-the [Description](#description) section below.
+|Language      |Attribute           |Applies to         |Diagnostic
+|--------------|--------------------|-------------------|----------
+|C++17         |`[[nodiscard]]`     |Types and functions|Warning
+|Rust          |`#[must_use]`       |Types and functions|Warning
+|C (GCC, Clang)|`warn_unused_result`|Functions          |Warning
+|D (DIP 1038)  |`@mustUse`          |Types              |Error
 
 ## Description
+
+### Formal Specification
 
 `@mustUse` is a compiler-recognized user-defined attribute declared in the D
 runtime module `core.attribute`. It takes no arguments.
@@ -158,74 +153,38 @@ following is true:
 * it is the *AssignExpression* on the left-hand side of the comma in a
   *CommaExpression*.
 
-It is a compile-time error to discard an expression if either of the following
-is true:
+It is a compile-time error to discard an expression if all of the following are
+true:
 
-* it is a call to a function whose declaration is annotated with
-  `@mustUse`, or
-* it is not an assignment expression, and its type is an aggregate (a `struct`,
-  `union`, `class`, or `interface`) whose declaration is annotated with
+* it is not an assignment expression, an increment expression, or a decrement
+  expression; and
+* its type is a `struct` or `union` type whose declaration is annotated with
   `@mustUse`.
 
-Note that the former is a syntax-level check, while the latter is a type-level
-check. This means that the *value* returned from a `@mustUse`-annotated
-function may be discarded as long as the function call itself is
-enclosed in some other expression. For example:
+An assignment expression is either a [simple assignment expression][SimpleAssign]
+or an [assignment operator expression][OperatorAssign].
 
-```d
-// un-annotated type
-struct Result { int n; }
+[SimpleAssign]: https://dlang.org/spec/expression.html#simple_assignment_expressions
+[OperatorAssign]: https://dlang.org/spec/expression.html#assignment_operator_expressions
 
-// @mustUse-annotated function
-@mustUse Result func() { return Result(0); }
+An increment expression is a *UnaryExpression* or *PostfixExpression* whose
+operator is `++`.
 
-void main()
-{
-    import std.stdio: writeln;
+A decrement expression is a *UnaryExpression* or *PostfixExpression* whose
+operator is `--`.
 
-    // no error: the return value of func is "used" by the comma expression
-    (writeln("side effect"), func());
-}
-```
+It is a compile-time error to annotate any function declaration or aggregate
+declaration other than a `struct` or `union` declaration with the `@mustUse`
+attribute. The purpose of this rule is to reserve such usage for possible
+future expansion.
 
-By contrast, a value of a `@mustUse`-annotated type will always cause an
-error if it is discarded, regardless of the expression that discards it:
+### Diagnostics
 
-```d
-// @mustUse-annotated type
-@mustUse struct Result { int n; }
-
-// un-annotated function
-Result func() { return Result(0); }
-
-void main()
-{
-    import std.stdio: writeln;
-
-    // error: the return type of func is also the type of the comma expression
-    (writeln("side effect"), func());
-}
-```
-
-In all cases, an error resulting from `@mustUse` can be suppressed by
-prepending `cast(void)` to the offending expression, since a *CastExpression*
-is not a function call and `void` is not an aggregate type annotated with
-`@mustUse`.
-
-Using `@mustUse` has no effects on the semantics of a program other than
-those described above. In particular:
-
-* `@mustUse` is not part of the type of any symbol to which it is applied to and does
-  not participate in name mangling.
-* A `@mustUse` annotation on a function or aggregate declaration does not
-  apply to declarations inside that function or aggregate's body (that is,
-  `@mustUse` does not implicitly propagate from outer scopes to inner ones).
-* `@mustUse` has no semantic effect on declarations other than aggregate and
-  function declarations.
-* `@mustUse` has no effect on declarations other than the ones to which it is
-  explicitly applied. In particular, a `@mustUse` annotation on a class is
-  not inherited by classes that inherit from it, and a `@mustUse` annotation
-  on a virtual function is not inherited by functions that override it.
+An error resulting from `@mustUse` can be suppressed by prepending `cast(void)`
+to the offending expression, since `void` is not a `struct` or `union` type
+annotated with `@mustUse`. The error message for discarding an expression of a
+`@mustUse` type should suggest using `cast(void)` if the programmer intended to
+discard the expression.
 
 ### Design Goals and Possible Alternatives
 
@@ -242,148 +201,97 @@ possible balance among the following goals:
    makes future improvements to both the language and its compilers more
    difficult to achieve.
 
-3. **Lack of friction.** A language feature is only useful in practice to the
-   extent that programmers choose to use it. If a feature places any
-   obstacles in the programmer's way (such as additional compile-time errors),
-   it must offer benefits commensurate with that cost.
+3. **Rigor.** A language feature that provides strong guarantees that
+   programmers can rely on is more useful that one that provides weak
+   guarantees or permits exceptions and special cases. Rigorous language
+   features compose more easily than non-rigorous ones.
 
 A few possible alternative designs, along with the reasons for their rejection,
 are discussed below.
 
-#### Dataflow analysis
+#### `@mustUse` as a function attribute
 
-As noted above, the design presented in this DIP allows "false negatives":
-expressions in which the return value of a `@mustUse`-annotated function is
-discarded without triggering a compile-time error.
-
-One way to avoid false negatives would be to have the compiler perform dataflow
-analysis to determine which expressions could potentially evaluate to the
-return value of a `@mustUse`-annotated function, and issue an error if any of
-those expressions were discarded.
-
-Whole-program dataflow analysis would completely eliminate false negatives, but
-its costs in terms of both implementation complexity and compile-time
-performance would likely be prohibitive. Intra-procedural dataflow analysis, on
-the other hand, would be more feasible to implement, but would still allow
-false negatives in some cases. For example:
+As described above, `@mustUse` is restricted to use with user-defined `struct`
+and `union` types, and cannot easily be applied to functions that return other
+kinds of types. One way to address this shortcoming would be to allow
+`@mustUse` to be used as a function attribute. For example:
 
 ```d
 @mustUse int dontIgnoreMe() { return 42; }
-int identity(int n) { return n; }
 
 void main()
 {
-    // no error: identity is not annotated with @mustUse
-    identity(dontIgnoreMe());
-}
-```
-
-In either case, the implementation complexity of a dataflow-analysis-based
-design would be far greater than that of the design proposed by this DIP. If
-written with sufficient detail to fully describe the implementation's behavior,
-the specification's complexity would be significantly greater as well.
-
-#### `mustUse` type qualifier
-
-Another way to avoid false negatives would be to make `mustUse` a type
-qualifier rather than an attribute. This would allow the type-level check,
-which does not suffer from false negatives, to be applied to return values of
-*any* type, not just user-defined aggregate types, and eliminate the need for
-the syntax-level check.
-
-Because type qualifiers are an established concept in the language
-specification with an existing implementation, the specification and
-implementation complexity of a `mustUse` type qualifier would likely be
-relatively low.
-
-Unfortunately, making `mustUse` a type qualifier would introduce significant
-friction in the form of "false positives": expressions that do not discard a
-`mustUse`-qualified value, but are diagnosed by the compiler as though they
-do. For example:
-
-```d
-mustUse(int) dontIgnoreMe() { return 42; }
-int identity(int n) { return n; }
-
-void main()
-{
-    // error: cannot pass mustUse(int) argument to int parameter
-    auto result = identity(dontIgnoreMe());
-}
-```
-
-This friction would be particularly severe for programmers attempting to make
-newly-written D code that uses `mustUse` work together with existing D code
-that does not—in other words, for `mustUse`'s earliest adopters. The most
-likely result would be a language feature that, while theoretically more sound,
-would provide less utility to D programmers in practice than the design
-proposed by this DIP.
-
-#### Type-only `@mustUse` attribute
-
-Perhaps the easiest way to avoid false negatives would be to simply drop the
-syntax-level check and recognize the `@mustUse` attribute only when applied
-to an aggregate type. The resulting design would be strictly less complex in
-terms of both specification and implementation than the one this DIP proposes,
-and would not introduce any risk of false positives.
-
-However, choosing this design would introduce friction of a different sort: a
-higher barrier to adoption. Consider the following example:
-
-```d
-int dontIgnoreMe() { return 42; }
-void useResult(int n) {}
-
-void ok()
-{
-    useResult(dontIgnoreMe());
-}
-
-void noGood()
-{
+    // error: cannot discard return value of @mustUse function `dontIgnoreMe`
     dontIgnoreMe();
 }
 ```
 
-Suppose that we would like to use `@mustUse` to ensure that the return value
-of `dontIgnoreMe` is not discarded. With the design for `@mustUse` proposed
-by this DIP, there are two ways we can go about it:
+The main challenge for this design is deciding how to deal with statements that
+discard the return value of a `@mustUse` function indirectly. For example:
 
-1. We can annotate `dontIgnoreMe` with `@mustUse`.
-2. We can change the return type of `dontIgnoreMe` to a `@mustUse`-annotated
-   type.
+```d
+a ? b : dontIgnoreMe();
+(writeln("side effect"), dontIgnoreMe());
+(() => dontIgnoreMe())();
+```
 
-If we choose (1), the only other change we need to make is to update the call
-site in `noGood`, which discards the return value. The call site in `ok` is
-already correct and can be left alone.
+There are two possibilities:
 
-If we choose (2), however, we must update *every* call site of `dontIgnoreMe`,
-whether it discards the return value or not. If our program were larger, the
-prospect of doing so might discourage us from using `@mustUse` in the first
-place.
+1. **Error.** This requires all discarded expressions to be searched,
+   recursively, for calls to `@mustUse` functions in positions where their
+   return values might be discarded.
+2. **No error.** This allows return values of `@mustUse` functions to be
+   accidentally discarded in some cases, without an explicit cast or type
+   conversion.
 
-Making `@mustUse` meaningful only as a type attribute, without the
-syntax-level check, would leave D programmers with only choice (2). As a
-result, while programmers who did choose to use `@mustUse` might be better
-off, there would be fewer of them than there would be if choice (1) were also
-available. On balance, the author believes that the design proposed by this DIP
-is likely to be more useful to more D programmers in practice than one which
-excludes the syntax-level check.
+Option (1) sacrificies spec and implementation simplicity to maintain rigor;
+option (2) sacrifices rigor to maintain simplicity.
 
-The experience of other languages appears to support this hypothesis. In C and
-C++, the syntax-level check was considered useful enough to be worth including
-on its own. In Rust, the syntax-level check was considered useful enough to be
-worth including (via [RFC 1940][Rfc1940]) even with the more rigorous
-type-level check already in the language.
+Rather than make either sacrifice, this DIP proposes a design that allows both
+rigor and simplicity to be maintained, and reserves the possibility for a
+future DIP to allow `@mustUse` as a function attribute.
 
-Nevertheless, if the language maintainers are not prepared to accept the
-syntax-level check at this time, accepting `@mustUse` as an attribute only
-for types, with a type-level check, is a compromise that would preserve many of
-the benefits of this DIP's proposal. In that case, to allow for the possibility
-of future expansion, annotating a function with `@mustUse` should result in a
-compile-time error.
+#### `@mustUse` as a class attribute
 
-[Rfc1940]: https://rust-lang.github.io/rfcs/1940-must-use-functions.html
+As described above, `@mustUse` cannot be applied to `class` or `interface`
+types. Allowing this usage would make `@mustUse` more widely applicable.
+
+The main challenge for this design is deciding how to deal with `@mustUse`
+subclasses. For example:
+
+```d
+class Parent {}
+@mustUse class Child : Parent {}
+
+Parent fun() { return new Child(); }
+
+void main()
+{
+    fun();
+}
+```
+
+Again, there are two possibilities:
+
+1. **Error.** This requires that if a child class is annotated with `@mustUse`,
+   its parent class must also be annotated with `@mustUse`.
+2. **No error.** This allows values of `@mustUse` class types to be
+   accidentally discarded in some cases, without an explicit cast or type
+   conversion.
+
+Because every D class inherits from `Object` and `Object` is not annotated with
+`@mustUse`, choosing option (1) would mean restricting `@mustUse` to
+`interface` types and non-D `class` types (i.e., `extern(C++)`,
+`extern(Objective-C)`, and COM classes). It is uncertain whether such a
+restricted version of `@mustUse` would be worth the complexity cost of
+specifying and implementing it.
+
+Conversely, option (2) is simpler to specify and implement, but the guarantee
+it provides is so weak as to make it nearly useless.
+
+Since both options are unattractive, this DIP chooses neither, but reserves the
+possibility for a future DIP to allow `@mustUse` as an attribute for classes
+and interfaces.
 
 ## Breaking Changes and Deprecations
 

--- a/DIPs/DIP1038.md
+++ b/DIPs/DIP1038.md
@@ -11,10 +11,10 @@
 ## Abstract
 
 This DIP proposes a new attribute, `@mustUse`, which can be applied to a
-`struct`, `union`, or `enum` type to make ignoring an expression of that type
-into a compile-time error. It can be used to implement alternative
-error-handling mechanisms for code that cannot use exceptions, including
-`@nogc` and BetterC code.
+`struct` or `union` type to make ignoring an expression of that type into a
+compile-time error. It can be used to implement alternative error-handling
+mechanisms for code that cannot use exceptions, including `@nogc` and BetterC
+code.
 
 ## Contents
 * [Rationale](#rationale)
@@ -159,8 +159,8 @@ true:
 
 * it is not an assignment expression, an increment expression, or a decrement
   expression; and
-* its type is a `struct`, `union`, or `enum` type whose declaration is
-  annotated with `@mustUse`.
+* its type is a `struct` or `union` type whose declaration is annotated with
+  `@mustUse`.
 
 An assignment expression is either a [simple assignment expression][SimpleAssign]
 or an [assignment operator expression][OperatorAssign].
@@ -175,17 +175,17 @@ A decrement expression is a *UnaryExpression* or *PostfixExpression* whose
 operator is `--`.
 
 It is a compile-time error to annotate any function declaration or aggregate
-declaration other than a `struct`, `union`, or `enum` declaration with the
-`@mustUse` attribute. The purpose of this rule is to reserve such usage for
-possible future expansion.
+declaration other than a `struct` or `union` declaration with the `@mustUse`
+attribute. The purpose of this rule is to reserve such usage for possible
+future expansion.
 
 ### Diagnostics
 
 An error resulting from `@mustUse` can be suppressed by prepending `cast(void)`
-to the offending expression, since `void` is not a `struct`, `union`, or `enum`
-type annotated with `@mustUse`. The error message for discarding an expression
-of a `@mustUse` type should suggest using `cast(void)` if the programmer
-intended to discard the expression.
+to the offending expression, since `void` is not a `struct` or `union` type
+annotated with `@mustUse`. The error message for discarding an expression of a
+`@mustUse` type should suggest using `cast(void)` if the programmer intended to
+discard the expression.
 
 ### Design Goals and Possible Alternatives
 
@@ -212,10 +212,10 @@ are discussed below.
 
 #### `@mustUse` as a function attribute
 
-As described above, `@mustUse` is restricted to use with user-defined `struct`,
-`union`, and `enum` types, and cannot easily be applied to functions that
-return other kinds of types. One way to address this shortcoming would be to
-allow `@mustUse` to be used as a function attribute. For example:
+As described above, `@mustUse` is restricted to use with user-defined `struct`
+and `union` types, and cannot easily be applied to functions that return other
+kinds of types. One way to address this shortcoming would be to allow
+`@mustUse` to be used as a function attribute. For example:
 
 ```d
 // Hypothetical usage

--- a/DIPs/DIP1038.md
+++ b/DIPs/DIP1038.md
@@ -218,6 +218,7 @@ kinds of types. One way to address this shortcoming would be to allow
 `@mustUse` to be used as a function attribute. For example:
 
 ```d
+// Hypothetical usage
 @mustUse int dontIgnoreMe() { return 42; }
 
 void main()
@@ -262,6 +263,7 @@ subclasses. For example:
 
 ```d
 class Parent {}
+// Hypothetical usage
 @mustUse class Child : Parent {}
 
 Parent fun() { return new Child(); }

--- a/DIPs/DIP1038.md
+++ b/DIPs/DIP1038.md
@@ -11,10 +11,10 @@
 ## Abstract
 
 This DIP proposes a new attribute, `@mustUse`, which can be applied to a
-`struct` or `union` type to make ignoring an expression of that type into a
-compile-time error. It can be used to implement alternative error-handling
-mechanisms for code that cannot use exceptions, including `@nogc` and BetterC
-code.
+`struct`, `union`, or `enum` type to make ignoring an expression of that type
+into a compile-time error. It can be used to implement alternative
+error-handling mechanisms for code that cannot use exceptions, including
+`@nogc` and BetterC code.
 
 ## Contents
 * [Rationale](#rationale)
@@ -159,8 +159,8 @@ true:
 
 * it is not an assignment expression, an increment expression, or a decrement
   expression; and
-* its type is a `struct` or `union` type whose declaration is annotated with
-  `@mustUse`.
+* its type is a `struct`, `union`, or `enum` type whose declaration is
+  annotated with `@mustUse`.
 
 An assignment expression is either a [simple assignment expression][SimpleAssign]
 or an [assignment operator expression][OperatorAssign].
@@ -175,17 +175,17 @@ A decrement expression is a *UnaryExpression* or *PostfixExpression* whose
 operator is `--`.
 
 It is a compile-time error to annotate any function declaration or aggregate
-declaration other than a `struct` or `union` declaration with the `@mustUse`
-attribute. The purpose of this rule is to reserve such usage for possible
-future expansion.
+declaration other than a `struct`, `union`, or `enum` declaration with the
+`@mustUse` attribute. The purpose of this rule is to reserve such usage for
+possible future expansion.
 
 ### Diagnostics
 
 An error resulting from `@mustUse` can be suppressed by prepending `cast(void)`
-to the offending expression, since `void` is not a `struct` or `union` type
-annotated with `@mustUse`. The error message for discarding an expression of a
-`@mustUse` type should suggest using `cast(void)` if the programmer intended to
-discard the expression.
+to the offending expression, since `void` is not a `struct`, `union`, or `enum`
+type annotated with `@mustUse`. The error message for discarding an expression
+of a `@mustUse` type should suggest using `cast(void)` if the programmer
+intended to discard the expression.
 
 ### Design Goals and Possible Alternatives
 
@@ -212,10 +212,10 @@ are discussed below.
 
 #### `@mustUse` as a function attribute
 
-As described above, `@mustUse` is restricted to use with user-defined `struct`
-and `union` types, and cannot easily be applied to functions that return other
-kinds of types. One way to address this shortcoming would be to allow
-`@mustUse` to be used as a function attribute. For example:
+As described above, `@mustUse` is restricted to use with user-defined `struct`,
+`union`, and `enum` types, and cannot easily be applied to functions that
+return other kinds of types. One way to address this shortcoming would be to
+allow `@mustUse` to be used as a function attribute. For example:
 
 ```d
 // Hypothetical usage


### PR DESCRIPTION
In accordance with Walter and Atila's feedback,

* `@nodiscard` is renamed to `@mustUse`.
* `@mustUse` is only allowed on user-defined types, not functions.
* "Design Goals and Possible Alternatives" is updated to reflect the above changes.

In addition, an oversight in the previous version of the DIP has been corrected: 

* ~~`@mustUse` is now allowed on `enum` types, not just aggregate types.~~ Reverted due to issues pointed out in review; see comments below.