### PR TITLE
DIP 1038: use relative link, not absolute

### DIFF
--- a/DIPs/accepted/DIP1038.md
+++ b/DIPs/accepted/DIP1038.md
@@ -364,6 +364,6 @@ The language maintainers accepted this DIP with a request for changes:
 * address issues that arise from the feature's interaction with inheritance when applied to classes.
 * develop rules for handling covariance and contravariance when applied to functions.
 
-The DIP author addressed these requests by renaming the attribute to `@mustUse` and allowing it only on structs and unions. His rationale for the latter is described in the section, [Design Goals and Possible Alternatives](https://github.com/dlang/DIPs/blob/master/DIPs/DIP1038.md#design-goals-and-possible-alternatives).
+The DIP author addressed these requests by renaming the attribute to `@mustUse` and allowing it only on structs and unions. His rationale for the latter is described in the section, [Design Goals and Possible Alternatives](#design-goals-and-possible-alternatives).
 
 The maintainers approved the author's changes and accepted the revised version of the DIP.


### PR DESCRIPTION
previously, the absolute link at the bottom of the page to "Design Goals and Possible Alternatives" had broken as a result of this dip being accepted. this change makes it into a regular anchor link, as all other anchor links are.