### PR TITLE
Fix DIP1023 abstract

### DIFF
--- a/DIPs/other/DIP1023.md
+++ b/DIPs/other/DIP1023.md
@@ -22,13 +22,14 @@
 D has type aliases that can be templates:
 ```d
 struct TemplateType(T) { }
-alias TemplateAlias(T) = TemplateType!T
+alias TemplateAlias(T) = TemplateType!T;
 ```
 
 D also has template functions for which the template parameters are resolved when the template is instantiatied:
 ```d
 struct TemplateType(T) { }
-void templateFunction(TemplateType!T arg) { }
+void templateFunction(T)(TemplateType!T arg) { }
+
 TemplateType!int inst;
 templateFunction(inst); /* template instantiated with T = int */
 ```
@@ -37,11 +38,12 @@ Combining template aliases and template functions, it should be possible to have
 as formal parameter types of template functions:
 ```d
 struct TemplateType(T) { }
-alias TemplateAlias(T) = TemplateType!T
-void templateFunction(TemplateAlias!T arg) { }
+alias TemplateAlias(T) = TemplateType!T;
+void templateFunction(T)(TemplateAlias!T arg) { }
 ```
 
-However, the compiler produces an error when a template alias is used as a formal function parameter.
+However, the compiler produces an error when trying to use IFTI to call a template function
+that has a template alias type instance as a formal function parameter.
 This is not a bug because the desired behaviour is not specified. As such, [existing reports of the issue](#reference) are tagged as 'Enhancements'.
 
 This DIP proposes a specification for template aliases as formal function parameters.
@@ -60,7 +62,7 @@ The following example demonstrates a possible real-world example using the Mir l
 ```d
 alias PackedUpperTriangularMatrix(T) = Slice!(StairsIterator!(T*, "-"));
 
-// fails, issue 16486
+// IFTI will fail, issue 16486
 auto foo(T)(PackedUpperTriangularMatrix!T m) { }
 ```
 
@@ -92,7 +94,7 @@ void main()
 }
 ```
 We get the following error message:
-```d
+```
 template templateFunction cannot deduce function from argument types !()(TemplateType!int), candidates are:
 templateFunction(T)(TemplateAlias!T arg)
 ```


### PR DESCRIPTION
2 declarations were each missing a template parameter. 
It didn't mention IFTI (implying that calling the function with explicit template arguments was an error or that just declaring the template function was an error).